### PR TITLE
feat(summary): summarize long pages in sections; wire up settings that did nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter — a stacked PR whose base is another feature branch
+  # must still be checked. Filtering on [main] silently gave those PRs no checks
+  # at all, which looks identical to "nothing to run".
   pull_request:
-    branches: [main]
 
 jobs:
   verify:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [5.1.0]
 
 ### Added
+- **Automatic retry on transient provider failures.** `429`, `5xx`, and network
+  blips are retried twice with exponential backoff and jitter, honouring
+  `Retry-After`. Errors meaning the request itself is wrong (`400`, `401`,
+  `403`, `404`) are never retried — that burns quota and delays the message the
+  user needs. Timeouts are not retried either, since the request may still be
+  running provider side.
+
+  This became necessary because of chunking below: turning one request into up
+  to nine meant a single transient failure discarded every section that had
+  already succeeded.
+- **Bounded section concurrency.** Sections are summarized three at a time
+  rather than all at once. Firing eight simultaneous requests is a reliable way
+  to trip the per-minute rate limit and fail exactly the long pages the feature
+  exists for.
+- Chat now states, once per session, when a page is too long to fit a single
+  request, so an answer drawn from part of a page never looks exhaustive.
 - **Chunked summarization.** Pages over 24,000 characters are split on paragraph
   boundaries, summarized section by section, and merged into one summary instead
   of being silently truncated. Capped at 8 sections (9 requests) so one click

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the GenAI Browser Tool project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0]
+
+### Added
+- **Chunked summarization.** Pages over 24,000 characters are split on paragraph
+  boundaries, summarized section by section, and merged into one summary instead
+  of being silently truncated. Capped at 8 sections (9 requests) so one click
+  cannot run away with an API budget; the popup always states the coverage it
+  achieved.
+- Entity extraction is now reachable from the Analyze tab. The backend action
+  existed but no button called it.
+- Translation honours the "From" language selector, which was previously only
+  used by the swap button and never sent to the provider.
+
+### Fixed
+- The popup ignored saved preferences. Summary style, summary length, target
+  language, and theme were stored by the options page but never applied, so
+  changing them appeared to do nothing.
+- Theme choice is now persisted rather than reset on every popup open.
+
+### Removed
+- Four controls with no handler behind them: "Save Summary", "Speak", "Create
+  Bookmark", and the "Preserve formatting" checkbox. Summaries are already saved
+  to history automatically when generated.
+
 ## [5.0.0]
 
 Makes the extension actually perform AI work. Prior versions shipped stub

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ is no backend, no telemetry, and no third party in between.
 
 | Feature | Where | How it works |
 | --- | --- | --- |
-| Page summary | Popup → Summary | Four styles (key points, TL;DR, executive, technical) × four lengths |
+| Page summary | Popup → Summary | Four styles (key points, TL;DR, executive, technical) × four lengths. Long pages are summarized in sections — see below |
 | Ask about the page | Popup → Chat | Grounded in the extracted page text, with the last few turns as context |
-| Translate | Popup → Translate | Whole page, or the first 2,000 characters |
+| Translate | Popup → Translate | Whole page or first 2,000 characters, with an optional source language |
 | Sentiment | Popup → Analyze | A label plus a one-line reason |
 | Key insights | Popup → Analyze | Up to seven bullet points |
+| Entities | Popup → Analyze | People, organizations, places, products, dates |
 | Smart tags | Popup → Analyze | 3–8 topic tags |
 | Readability | Popup → Analyze | Flesch reading ease — computed locally, no API call |
 | Page stats | Popup → Tools | Word/character/heading counts and read time, computed locally |
@@ -24,6 +25,26 @@ is no backend, no telemetry, and no third party in between.
 | Export | Popup → Tools | Downloads saved summaries and chats as JSON |
 | Right-click actions | Any page | Summarize / explain / translate / sentiment on a selection; summarize, insights, or tags on the page |
 | `Ctrl+Shift+S` | Any page | Summarize the current page |
+
+### Long pages
+
+A page that exceeds 24,000 characters no longer gets silently truncated. It is
+split on paragraph boundaries into sections, each summarized in its own request,
+and the notes are merged into one summary — map-reduce, costing one request per
+section plus one to merge.
+
+This is capped at **8 sections (~192,000 characters, so 9 requests)** so a single
+click cannot run away with your API budget. The popup always states the coverage
+it achieved:
+
+| What you see | Meaning |
+| --- | --- |
+| `Whole page` | Fit in one request |
+| `Whole page, summarized across 4 sections` | Split, nothing dropped |
+| `Very long page — summarized the first 8 sections, 51,000 characters not included` | Hit the cap |
+
+Chat, translation, and the analysis actions still use a single request and
+truncate at 24,000 characters.
 
 ### What it deliberately does not do
 
@@ -177,7 +198,8 @@ page requires reading it. It has no network access of its own.
 | "Cannot read this page" | Content scripts cannot run on `chrome://` pages, the Chrome Web Store, or PDFs |
 | "returned 401" | The key is wrong, revoked, or belongs to a different provider |
 | "returned 429" | You hit the provider's rate limit |
-| "Long page — summarized from the first section only" | Page exceeded 24,000 characters; only the first section was sent |
+| "…characters not included" | Page exceeded the 8-section cap; see [Long pages](#long-pages) |
+| A long page costs several requests | Expected — one per section plus one merge |
 | Popup unchanged after an edit | Reload the extension at `chrome://extensions`, then reopen the popup |
 
 Extension logs: `chrome://extensions` → **service worker** link under this
@@ -187,8 +209,9 @@ extension opens the background console.
 
 ## Known limitations
 
-- Long pages are truncated at 24,000 characters — no chunking or map-reduce
-  summarization.
+- Summarization handles long pages by sectioning, but chat, translation, and the
+  analysis actions still truncate at 24,000 characters.
+- Pages beyond ~192,000 characters are summarized only up to the 8-section cap.
 - Only the primary content container is extracted; heavily JavaScript-rendered or
   shadow-DOM pages may yield little text.
 - Multi-tab comparison and cross-page reasoning are not implemented.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,28 @@ it achieved:
 | `Whole page, summarized across 4 sections` | Split, nothing dropped |
 | `Very long page — summarized the first 8 sections, 51,000 characters not included` | Hit the cap |
 
+Sections are summarized a few at a time rather than all at once — eight
+simultaneous requests is a reliable way to trip a per-minute rate limit and fail
+the very long pages the feature exists for.
+
 Chat, translation, and the analysis actions still use a single request and
-truncate at 24,000 characters.
+truncate at 24,000 characters. Chat says so in the thread the first time it
+happens, so an answer drawn from part of a page never looks exhaustive.
+
+### When a request fails
+
+Transient failures — `429`, `500`, `502`, `503`, `504`, `529`, and network blips
+— are retried twice with exponential backoff and jitter, honouring the
+provider's `Retry-After` header when it sends one.
+
+Errors that mean *this request is wrong* are **not** retried: `400`, `401`,
+`403`, `404`. Retrying those burns quota and delays the message you need to see.
+Timeouts are not retried either, since the request may still be running on the
+provider's side and a retry risks paying for the same work twice.
+
+If a section still fails after retries, the whole summary fails with the
+provider's own message. A partial summary presented as complete would be worse
+than an error.
 
 ### What it deliberately does not do
 
@@ -197,7 +217,7 @@ page requires reading it. It has no network access of its own.
 | "No API key configured" | Open the options page and add a key for the selected provider |
 | "Cannot read this page" | Content scripts cannot run on `chrome://` pages, the Chrome Web Store, or PDFs |
 | "returned 401" | The key is wrong, revoked, or belongs to a different provider |
-| "returned 429" | You hit the provider's rate limit |
+| "returned 429" | Rate limit, still hit after two retries — wait, or lower the request rate |
 | "…characters not included" | Page exceeded the 8-section cap; see [Long pages](#long-pages) |
 | A long page costs several requests | Expected — one per section plus one merge |
 | Popup unchanged after an edit | Reload the extension at `chrome://extensions`, then reopen the popup |

--- a/background.js
+++ b/background.js
@@ -5,7 +5,13 @@
  */
 
 import { ConfigurationManager } from './core/configuration-manager.js';
-import { buildPrompt, parseSentiment, parseTags, wasTruncated } from './core/tasks.js';
+import {
+  buildPrompt,
+  chunkContent,
+  parseSentiment,
+  parseTags,
+  wasTruncated
+} from './core/tasks.js';
 import { AIError } from './providers/ai-client.js';
 import { StorageService } from './services/storage-service.js';
 import { NotificationManager } from './services/notification-manager.js';
@@ -183,26 +189,95 @@ class BackgroundService {
     };
   }
 
-  /** @param {any} payload */
+  /**
+   * Summarize a page, splitting it across requests when it is too long for one.
+   *
+   * @param {any} payload
+   */
   async summarize(payload) {
-    const result = await this.runTask('summary', payload);
+    const content = (payload.content || '').trim();
+    if (!content) {
+      throw new AIError('NO_CONTENT', 'No page content available for this action');
+    }
+
+    const client = await this.configManager.createAIClient();
+    const { chunks, droppedChars } = chunkContent(content);
+
+    const result = chunks.length > 1
+      ? await this.summarizeInChunks(client, chunks, payload)
+      : { text: await this.completeTask(client, 'summary', { ...payload, content }) };
 
     await this.storageService.saveSummaryHistory({
-      originalContent: payload.content.slice(0, 500),
+      originalContent: content.slice(0, 500),
       summary: result.text,
       options: { type: payload.summaryType, length: payload.targetLength },
-      provider: result.provider,
+      provider: client.provider,
       timestamp: Date.now()
     });
 
     return {
-      ...result,
+      text: result.text,
       summary: result.text,
+      provider: client.provider,
+      model: client.model,
+      sections: chunks.length,
+      droppedChars,
+      truncated: droppedChars > 0,
       stats: {
-        inputLength: payload.content.length,
+        inputLength: content.length,
         outputLength: result.text.length
       }
     };
+  }
+
+  /**
+   * Map-reduce over a long page: summarize each section, then merge the notes.
+   *
+   * Sections run concurrently — a nine-request sequential chain would take most
+   * of a minute, and the popup is a foreground UI. A rate-limit rejection on any
+   * section fails the whole summary with the provider's own message, which is
+   * the honest outcome; a partial summary presented as complete is not.
+   *
+   * @param {import('./providers/ai-client.js').AIClient} client
+   * @param {string[]} chunks
+   * @param {any} payload
+   * @returns {Promise<{ text: string }>}
+   */
+  async summarizeInChunks(client, chunks, payload) {
+    this.logger.info(`Summarizing ${chunks.length} sections`);
+
+    const notes = await Promise.all(
+      chunks.map((chunk, index) =>
+        this.completeTask(client, 'summary-chunk', {
+          content: chunk,
+          index,
+          total: chunks.length
+        })
+      )
+    );
+
+    const text = await this.completeTask(client, 'summary-reduce', {
+      notes: notes.map((note, i) => `Section ${i + 1}:\n${note}`).join('\n\n'),
+      total: chunks.length,
+      title: payload.title,
+      summaryType: payload.summaryType,
+      targetLength: payload.targetLength
+    });
+
+    return { text };
+  }
+
+  /**
+   * Build a prompt and run it against an already-constructed client.
+   *
+   * @param {import('./providers/ai-client.js').AIClient} client
+   * @param {string} task
+   * @param {any} payload
+   * @returns {Promise<string>}
+   */
+  completeTask(client, task, payload) {
+    const prompt = buildPrompt(task, payload);
+    return client.complete(prompt.system, prompt.user, prompt.maxTokens);
   }
 
   /** @param {any} payload */

--- a/background.js
+++ b/background.js
@@ -19,6 +19,12 @@ import { ValidationService } from './src/utils/validation-service.js';
 import { Logger } from './utils/logger.js';
 
 /**
+ * Sections summarized at once. Low enough to stay under typical per-minute
+ * request limits, high enough that a long page does not feel serial.
+ */
+const SECTION_CONCURRENCY = 3;
+
+/**
  * Context menu id -> the task it runs and where its input comes from.
  * @type {Record<string, { task: string, source: 'selection' | 'page', title: string }>}
  */
@@ -233,10 +239,14 @@ class BackgroundService {
   /**
    * Map-reduce over a long page: summarize each section, then merge the notes.
    *
-   * Sections run concurrently — a nine-request sequential chain would take most
-   * of a minute, and the popup is a foreground UI. A rate-limit rejection on any
-   * section fails the whole summary with the provider's own message, which is
-   * the honest outcome; a partial summary presented as complete is not.
+   * Sections run a few at a time rather than all at once. Fully sequential
+   * would take most of a minute in a foreground popup; all eight at once is a
+   * reliable way to trip the per-minute rate limit and fail the very long pages
+   * this exists for. Individual requests retry transient failures themselves.
+   *
+   * A section that still fails after retries fails the whole summary, with the
+   * provider's own message. A partial summary presented as complete would be
+   * worse than an error.
    *
    * @param {import('./providers/ai-client.js').AIClient} client
    * @param {string[]} chunks
@@ -246,14 +256,12 @@ class BackgroundService {
   async summarizeInChunks(client, chunks, payload) {
     this.logger.info(`Summarizing ${chunks.length} sections`);
 
-    const notes = await Promise.all(
-      chunks.map((chunk, index) =>
-        this.completeTask(client, 'summary-chunk', {
-          content: chunk,
-          index,
-          total: chunks.length
-        })
-      )
+    const notes = await mapWithConcurrency(chunks, SECTION_CONCURRENCY, (chunk, index) =>
+      this.completeTask(client, 'summary-chunk', {
+        content: chunk,
+        index,
+        total: chunks.length
+      })
     );
 
     const text = await this.completeTask(client, 'summary-reduce', {
@@ -413,6 +421,31 @@ class BackgroundService {
  */
 function truncateForNotification(text) {
   return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+}
+
+/**
+ * Map over items with at most `limit` promises in flight, preserving order.
+ *
+ * @template T, R
+ * @param {T[]} items
+ * @param {number} limit
+ * @param {(item: T, index: number) => Promise<R>} fn
+ * @returns {Promise<R[]>}
+ */
+export async function mapWithConcurrency(items, limit, fn) {
+  /** @type {R[]} */
+  const results = new Array(items.length);
+  let next = 0;
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await fn(/** @type {T} */ (items[index]), index);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
 }
 
 new BackgroundService();

--- a/core/tasks.js
+++ b/core/tasks.js
@@ -8,8 +8,17 @@
  * content to be summarized, not a command.
  */
 
-/** Longest page excerpt sent to a provider. Keeps one request bounded and cheap. */
+/** Longest page excerpt sent to a provider in a single request. */
 export const MAX_CONTENT_CHARS = 24000;
+
+/**
+ * Most chunks a long page is split into for map-reduce summarization.
+ *
+ * Each chunk costs one request, so this is the ceiling on what a single
+ * "Summarize" click can spend: 8 chunks + 1 reduce = 9 calls, covering roughly
+ * 192,000 characters. Content past that is dropped and the UI says so.
+ */
+export const MAX_CHUNKS = 8;
 
 const FENCE = '<<<PAGE_CONTENT>>>';
 
@@ -67,6 +76,74 @@ export function wasTruncated(content) {
 }
 
 /**
+ * Split long text into chunks that each fit one request.
+ *
+ * Splits on blank lines so a chunk boundary lands between paragraphs rather
+ * than mid-sentence — a summary of half a sentence is worse than a slightly
+ * uneven split. A single paragraph longer than the limit is hard-split, since
+ * there is no better boundary available.
+ *
+ * @param {string} text
+ * @param {number} [maxChars]
+ * @param {number} [maxChunks]
+ * @returns {{ chunks: string[], droppedChars: number }}
+ */
+export function chunkContent(text, maxChars = MAX_CONTENT_CHARS, maxChunks = MAX_CHUNKS) {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) {
+    return { chunks: trimmed ? [trimmed] : [], droppedChars: 0 };
+  }
+
+  /** @type {string[]} */
+  const chunks = [];
+  let current = '';
+
+  for (const paragraph of splitParagraphs(trimmed, maxChars)) {
+    // +2 for the blank line that rejoins them.
+    if (current && current.length + paragraph.length + 2 > maxChars) {
+      chunks.push(current);
+      current = paragraph;
+    } else {
+      current = current ? `${current}\n\n${paragraph}` : paragraph;
+    }
+  }
+  if (current) chunks.push(current);
+
+  if (chunks.length <= maxChunks) {
+    return { chunks, droppedChars: 0 };
+  }
+
+  const kept = chunks.slice(0, maxChunks);
+  const droppedChars = chunks.slice(maxChunks).reduce((total, c) => total + c.length, 0);
+  return { chunks: kept, droppedChars };
+}
+
+/**
+ * Paragraphs of `text`, with any paragraph longer than `maxChars` hard-split.
+ *
+ * @param {string} text
+ * @param {number} maxChars
+ * @returns {string[]}
+ */
+function splitParagraphs(text, maxChars) {
+  /** @type {string[]} */
+  const out = [];
+  for (const paragraph of text.split(/\n\s*\n/)) {
+    const clean = paragraph.trim();
+    if (!clean) continue;
+
+    if (clean.length <= maxChars) {
+      out.push(clean);
+      continue;
+    }
+    for (let i = 0; i < clean.length; i += maxChars) {
+      out.push(clean.slice(i, i + maxChars));
+    }
+  }
+  return out;
+}
+
+/**
  * Build the prompt pair for a task.
  *
  * @param {string} task
@@ -81,6 +158,35 @@ export function buildPrompt(task, payload) {
       return {
         system: `${GROUNDING} ${style}`,
         user: `Summarize this page.\n\n${fenceContent(payload.content)}`,
+        maxTokens
+      };
+    }
+
+    // Map step: one section of a long page. Asks for retained detail rather
+    // than a polished summary — this output is input to the reduce step, and
+    // compressing twice loses specifics the final summary needs.
+    case 'summary-chunk':
+      return {
+        system: `${GROUNDING} You are reading section ${payload.index + 1} of` +
+          ` ${payload.total} of a long page. List the substantive points from this` +
+          ' section as terse bullets, preserving names, numbers, and specifics.' +
+          ' Do not write an introduction or a conclusion — later sections follow.',
+        user: fenceContent(payload.content),
+        maxTokens: 700
+      };
+
+    // Reduce step: partial summaries are our own output, so they are trusted
+    // input and are not fenced.
+    case 'summary-reduce': {
+      const style = SUMMARY_STYLES[payload.summaryType] || DEFAULT_SUMMARY_STYLE;
+      const maxTokens = LENGTH_TOKENS[payload.targetLength] || DEFAULT_SUMMARY_TOKENS;
+      return {
+        system: `${style} You are given ordered notes taken from consecutive` +
+          ' sections of one page. Merge them into a single coherent summary of the' +
+          ' whole page. Remove duplication, keep specifics, and do not mention the' +
+          ' sections or that the page was processed in parts.',
+        user: `Notes from ${payload.total} sections of "${payload.title || 'the page'}":\n\n` +
+          payload.notes,
         maxTokens
       };
     }
@@ -102,13 +208,18 @@ export function buildPrompt(task, payload) {
       };
     }
 
-    case 'translation':
+    case 'translation': {
+      const from = payload.sourceLanguage && payload.sourceLanguage !== 'auto'
+        ? ` from ${payload.sourceLanguage}`
+        : '';
       return {
-        system: `${GROUNDING} Translate the page text into ${payload.targetLanguage || 'English'}.` +
+        system: `${GROUNDING} Translate the page text${from} into` +
+          ` ${payload.targetLanguage || 'English'}.` +
           ' Return only the translation, with no preamble and no commentary.',
         user: fenceContent(payload.text),
         maxTokens: 2000
       };
+    }
 
     case 'sentiment':
       return {

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,9 @@
 {
   "manifest_version": 3,
   "name": "GenAI Browser Tool",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Summarize, question, translate, and analyse the page you are on, using the AI provider and API key you choose.",
   "author": "Aaron Sequeira <aaronsequeira12@gmail.com>",
-
   "permissions": [
     "storage",
     "activeTab",
@@ -12,26 +11,27 @@
     "notifications",
     "alarms"
   ],
-
   "host_permissions": [
     "https://api.openai.com/*",
     "https://api.anthropic.com/*",
     "https://generativelanguage.googleapis.com/*"
   ],
-
   "background": {
     "service_worker": "background.js",
     "type": "module"
   },
-
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*"],
-      "js": ["content.js"],
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "content.js"
+      ],
       "run_at": "document_end"
     }
   ],
-
   "action": {
     "default_popup": "popup.html",
     "default_title": "GenAI Browser Tool",
@@ -42,20 +42,16 @@
       "128": "assets/icons/icon-128.png"
     }
   },
-
   "icons": {
     "16": "assets/icons/icon-16.png",
     "32": "assets/icons/icon-32.png",
     "48": "assets/icons/icon-48.png",
     "128": "assets/icons/icon-128.png"
   },
-
   "options_page": "options.html",
-
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"
   },
-
   "commands": {
     "quick-summarize": {
       "suggested_key": {
@@ -65,6 +61,5 @@
       "description": "Summarize the current page"
     }
   },
-
   "minimum_chrome_version": "116"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genai-browser-tool",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Chrome extension that summarizes, questions, translates, and analyses the current page using an AI provider and API key you supply.",
   "type": "module",
   "scripts": {

--- a/popup.html
+++ b/popup.html
@@ -103,10 +103,6 @@
                             <span class="button-icon">✨</span>
                             Generate Summary
                         </button>
-                        <button class="secondary-button" id="save-summary-btn" style="display: none;">
-                            <span class="button-icon">💾</span>
-                            Save Summary
-                        </button>
                     </div>
                     
                     <div class="results-container" id="summary-results" style="display: none;">
@@ -216,10 +212,6 @@
                                 <input type="checkbox" id="translate-page" checked>
                                 <span class="checkbox-text">Translate entire page</span>
                             </label>
-                            <label class="checkbox-label">
-                                <input type="checkbox" id="preserve-formatting">
-                                <span class="checkbox-text">Preserve formatting</span>
-                            </label>
                         </div>
                     </div>
                     
@@ -242,9 +234,6 @@
                         <div class="result-actions">
                             <button class="action-button" id="copy-translation-btn">
                                 📋 Copy
-                            </button>
-                            <button class="action-button" id="speak-translation-btn">
-                                🔊 Speak
                             </button>
                         </div>
                     </div>
@@ -298,6 +287,16 @@
                                 <div class="placeholder">Click extract to start</div>
                             </div>
                         </div>
+
+                        <div class="analysis-card">
+                            <div class="card-header">
+                                <h3>🏛️ Entities</h3>
+                                <button class="analyze-btn" data-type="entities">Extract</button>
+                            </div>
+                            <div class="analysis-result" id="entities-result">
+                                <div class="placeholder">People, organizations, places, products, dates</div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -310,13 +309,6 @@
                     </div>
                     
                     <div class="tools-grid">
-                        <div class="tool-card">
-                            <div class="tool-icon">📝</div>
-                            <h3>Smart Bookmark</h3>
-                            <p>Save page with AI-generated summary and tags</p>
-                            <button class="tool-button" id="smart-bookmark-btn">Create Bookmark</button>
-                        </div>
-                        
                         <div class="tool-card">
                             <div class="tool-icon">📤</div>
                             <h3>Export Data</h3>

--- a/providers/ai-client.js
+++ b/providers/ai-client.js
@@ -107,6 +107,24 @@ export class AIError extends Error {
 
 const DEFAULT_TIMEOUT_MS = 60000;
 
+/** Attempts after the first, for transient failures only. */
+const DEFAULT_MAX_RETRIES = 2;
+
+/**
+ * Statuses worth retrying: rate limits, gateway hiccups, and provider overload.
+ *
+ * 4xx codes that mean "this request is wrong" (400, 401, 403, 404) are absent
+ * deliberately — retrying them burns quota and delays an error the user needs
+ * to see. 529 is Anthropic's overloaded status.
+ */
+const RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504, 529]);
+
+const BASE_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 8000;
+
+/** @param {number} ms */
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
 export class AIClient {
   /**
    * @param {Object} options
@@ -114,8 +132,15 @@ export class AIClient {
    * @param {string} options.apiKey
    * @param {string} [options.model]   Overrides the provider default.
    * @param {number} [options.timeoutMs]
+   * @param {number} [options.maxRetries] Retries for transient failures only.
    */
-  constructor({ provider, apiKey, model, timeoutMs = DEFAULT_TIMEOUT_MS }) {
+  constructor({
+    provider,
+    apiKey,
+    model,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxRetries = DEFAULT_MAX_RETRIES
+  }) {
     const spec = PROVIDERS[provider];
     if (!spec) {
       throw new AIError('UNKNOWN_PROVIDER', `Unknown AI provider: ${provider}`);
@@ -132,6 +157,7 @@ export class AIClient {
     this.apiKey = apiKey;
     this.model = model || spec.defaultModel;
     this.timeoutMs = timeoutMs;
+    this.maxRetries = maxRetries;
   }
 
   /**
@@ -143,6 +169,29 @@ export class AIClient {
    * @returns {Promise<string>}
    */
   async complete(systemPrompt, userPrompt, maxTokens = 1024) {
+    const body = JSON.stringify(
+      this.spec.body(systemPrompt, userPrompt, this.model, maxTokens)
+    );
+
+    for (let attempt = 0; ; attempt++) {
+      const outcome = await this.attempt(body);
+
+      if (outcome.ok) return outcome.text;
+      if (!outcome.retryable || attempt >= this.maxRetries) throw outcome.error;
+
+      await sleep(backoffDelay(attempt, outcome.retryAfterMs));
+    }
+  }
+
+  /**
+   * One request. Reports whether a failure is worth retrying instead of
+   * throwing, so the caller owns the retry policy.
+   *
+   * @param {string} body
+   * @returns {Promise<{ ok: true, text: string } |
+   *   { ok: false, retryable: boolean, error: AIError, retryAfterMs?: number }>}
+   */
+  async attempt(body) {
     const { spec } = this;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
@@ -152,30 +201,82 @@ export class AIClient {
       response = await fetch(spec.url(this.model), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...spec.headers(this.apiKey) },
-        body: JSON.stringify(spec.body(systemPrompt, userPrompt, this.model, maxTokens)),
+        body,
         signal: controller.signal
       });
     } catch (error) {
       /** @type {any} */
       const err = error;
       if (err.name === 'AbortError') {
-        throw new AIError('TIMEOUT', `${spec.label} did not respond within ${this.timeoutMs}ms`);
+        // A timeout is not retried: the request may still be running provider
+        // side, and retrying risks paying for the same work twice.
+        return {
+          ok: false,
+          retryable: false,
+          error: new AIError('TIMEOUT', `${spec.label} did not respond within ${this.timeoutMs}ms`)
+        };
       }
-      throw new AIError('NETWORK_ERROR', `Could not reach ${spec.label}: ${err.message}`);
+      return {
+        ok: false,
+        retryable: true,
+        error: new AIError('NETWORK_ERROR', `Could not reach ${spec.label}: ${err.message}`)
+      };
     } finally {
       clearTimeout(timer);
     }
 
     if (!response.ok) {
-      throw new AIError(
-        response.status === 401 || response.status === 403 ? 'AUTH_ERROR' : 'PROVIDER_ERROR',
-        // The provider's own message is the useful part; it never contains the key.
-        `${spec.label} returned ${response.status}: ${await readErrorMessage(response)}`
-      );
+      const retryable = RETRYABLE_STATUSES.has(response.status);
+      const result = {
+        ok: /** @type {false} */ (false),
+        retryable,
+        error: new AIError(
+          response.status === 401 || response.status === 403 ? 'AUTH_ERROR' : 'PROVIDER_ERROR',
+          // The provider's own message is the useful part; it never contains the key.
+          `${spec.label} returned ${response.status}: ${await readErrorMessage(response)}`
+        )
+      };
+      const retryAfterMs = parseRetryAfter(response.headers?.get('retry-after'));
+      return retryAfterMs === undefined ? result : { ...result, retryAfterMs };
     }
 
-    return spec.parse(await response.json()).trim();
+    return { ok: true, text: spec.parse(await response.json()).trim() };
   }
+}
+
+/**
+ * How long to wait before the next attempt.
+ *
+ * A provider's own `Retry-After` beats our guess. Otherwise exponential backoff
+ * with jitter, so several sections retrying at once do not resynchronise into
+ * another burst against the same rate limit.
+ *
+ * @param {number} attempt  Zero-based index of the attempt that just failed.
+ * @param {number} [retryAfterMs]
+ * @returns {number}
+ */
+export function backoffDelay(attempt, retryAfterMs) {
+  if (retryAfterMs !== undefined) return Math.min(retryAfterMs, MAX_BACKOFF_MS);
+
+  const exponential = Math.min(BASE_BACKOFF_MS * 2 ** attempt, MAX_BACKOFF_MS);
+  return exponential + Math.random() * BASE_BACKOFF_MS;
+}
+
+/**
+ * Parse a `Retry-After` header, which may be seconds or an HTTP date.
+ *
+ * @param {string | null | undefined} value
+ * @returns {number | undefined} Milliseconds, or undefined if absent/unparseable.
+ */
+export function parseRetryAfter(value) {
+  if (!value) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) return undefined;
+  return Math.max(0, date - Date.now());
 }
 
 /**

--- a/scripts/popup-main.js
+++ b/scripts/popup-main.js
@@ -16,6 +16,8 @@ class PopupInterface {
     this.isProcessing = false;
     this.lastSummary = null;
     this.lastTranslation = null;
+    /** @type {any} */
+    this.preferences = null;
 
     this.initialize();
   }
@@ -23,11 +25,43 @@ class PopupInterface {
   async initialize() {
     this.setupEventListeners();
     try {
+      await this.applyPreferences();
       await this.updateProviderStatus();
       await this.extractCurrentPageContent();
     } finally {
       this.hideLoading();
     }
+  }
+
+  /**
+   * Seed the controls from saved settings.
+   *
+   * Without this the options page's summary style, length, language, and theme
+   * are stored but never applied, so changing them appears to do nothing.
+   */
+  async applyPreferences() {
+    const response = await this.send('GET_USER_PREFERENCES', {});
+    if (!response.success) return;
+
+    this.preferences = response.data;
+    setValue('summary-type', this.preferences.summaryType);
+    setValue('target-language', this.preferences.targetLanguage);
+
+    const length = /** @type {HTMLInputElement | null} */ (
+      document.querySelector(
+        `input[name="summary-length"][value="${this.preferences.summaryLength}"]`
+      )
+    );
+    if (length) length.checked = true;
+
+    if (this.preferences.theme === 'dark') {
+      document.body.classList.add('dark-theme');
+    }
+  }
+
+  async toggleTheme() {
+    const isDark = document.body.classList.toggle('dark-theme');
+    await this.send('UPDATE_USER_PREFERENCES', { theme: isDark ? 'dark' : 'light' });
   }
 
   setupEventListeners() {
@@ -39,7 +73,7 @@ class PopupInterface {
     });
 
     on('settings-btn', 'click', () => chrome.runtime.openOptionsPage());
-    on('theme-toggle', 'click', () => document.body.classList.toggle('dark-theme'));
+    on('theme-toggle', 'click', () => this.toggleTheme());
 
     on('generate-summary-btn', 'click', () => this.generateSummary());
     on('copy-summary-btn', 'click', () => this.copyToClipboard('summary-content'));
@@ -126,10 +160,7 @@ class PopupInterface {
       this.lastSummary = response.data;
       setHtml('summary-content', renderMarkdown(response.data.summary));
       setText('summary-provider', `${response.data.provider} · ${response.data.model}`);
-      setText(
-        'summary-confidence',
-        response.data.truncated ? 'Long page — summarized from the first section only' : ''
-      );
+      setText('summary-confidence', describeCoverage(response.data));
       show('summary-results');
     });
   }
@@ -170,7 +201,8 @@ class PopupInterface {
         text: translateWholePage
           ? this.pageContent.mainText
           : this.pageContent.mainText.slice(0, 2000),
-        targetLanguage: value('target-language') || 'en'
+        targetLanguage: value('target-language') || 'en',
+        sourceLanguage: value('source-language') || 'auto'
       });
 
       if (!response.success) throw new Error(response.error);
@@ -500,6 +532,29 @@ export function renderMarkdown(text) {
     .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
     .replace(/`(.+?)`/g, '<code>$1</code>')
     .replace(/\n/g, '<br>');
+}
+
+/**
+ * Say how much of the page the summary actually covers.
+ *
+ * A summary of a 200,000-character page that silently used the first 24,000 is
+ * indistinguishable from a complete one, so coverage is always stated.
+ *
+ * @param {{ sections?: number, droppedChars?: number }} data
+ * @returns {string}
+ */
+export function describeCoverage(data) {
+  const sections = data.sections || 1;
+  const dropped = data.droppedChars || 0;
+
+  if (dropped > 0) {
+    return `Very long page — summarized the first ${sections} sections, ` +
+      `${dropped.toLocaleString()} characters not included`;
+  }
+  if (sections > 1) {
+    return `Whole page, summarized across ${sections} sections`;
+  }
+  return 'Whole page';
 }
 
 /** @param {string} text @returns {number} */

--- a/scripts/popup-main.js
+++ b/scripts/popup-main.js
@@ -18,6 +18,7 @@ class PopupInterface {
     this.lastTranslation = null;
     /** @type {any} */
     this.preferences = null;
+    this.warnedAboutChatTruncation = false;
 
     this.initialize();
   }
@@ -185,6 +186,17 @@ class PopupInterface {
       }
 
       this.addChatMessage('assistant', response.data.answer);
+
+      // Chat sends a single request, so a long page is answered from its first
+      // section only. Saying so once beats letting the answer look exhaustive.
+      if (response.data.truncated && !this.warnedAboutChatTruncation) {
+        this.warnedAboutChatTruncation = true;
+        this.addChatMessage(
+          'assistant',
+          '_Note: this page is long, so answers use only its first section._'
+        );
+      }
+
       this.conversationHistory.push(
         { role: 'user', content: question },
         { role: 'assistant', content: response.data.answer }

--- a/tests/core/concurrency.test.js
+++ b/tests/core/concurrency.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { mapWithConcurrency } from '../../background.js';
+
+/** @param {number} ms */
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+describe('mapWithConcurrency', () => {
+  it('preserves input order regardless of completion order', async () => {
+    // Earlier items finish last, so a naive push-on-resolve would reorder them.
+    const result = await mapWithConcurrency([30, 20, 10, 0], 2, async delay => {
+      await sleep(delay);
+      return delay;
+    });
+
+    expect(result).toEqual([30, 20, 10, 0]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await mapWithConcurrency(Array.from({ length: 8 }, (_, i) => i), 3, async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await sleep(5);
+      inFlight -= 1;
+    });
+
+    // The whole point: eight sections must not become eight simultaneous
+    // requests, which is a reliable way to trip a per-minute rate limit.
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(1);
+  });
+
+  it('passes the index through', async () => {
+    const seen = await mapWithConcurrency(['a', 'b', 'c'], 2, async (item, index) =>
+      `${index}:${item}`
+    );
+    expect(seen).toEqual(['0:a', '1:b', '2:c']);
+  });
+
+  it('handles an empty list without spawning workers', async () => {
+    await expect(mapWithConcurrency([], 3, async () => 1)).resolves.toEqual([]);
+  });
+
+  it('handles fewer items than the limit', async () => {
+    await expect(mapWithConcurrency([1, 2], 8, async n => n * 2)).resolves.toEqual([2, 4]);
+  });
+
+  it('propagates a rejection', async () => {
+    await expect(
+      mapWithConcurrency([1, 2, 3], 2, async n => {
+        if (n === 2) throw new Error('section failed');
+        return n;
+      })
+    ).rejects.toThrow('section failed');
+  });
+});

--- a/tests/core/tasks.test.js
+++ b/tests/core/tasks.test.js
@@ -3,10 +3,26 @@ import {
   buildPrompt,
   fenceContent,
   wasTruncated,
+  chunkContent,
   parseSentiment,
   parseTags,
-  MAX_CONTENT_CHARS
+  MAX_CONTENT_CHARS,
+  MAX_CHUNKS
 } from '../../core/tasks.js';
+
+/**
+ * Build text of roughly `chars` characters made of separate paragraphs, so the
+ * chunker has real boundaries to split on.
+ *
+ * @param {number} chars
+ * @param {number} [paragraphLength]
+ */
+function paragraphs(chars, paragraphLength = 1000) {
+  const count = Math.ceil(chars / paragraphLength);
+  return Array.from({ length: count }, (_, i) =>
+    `Paragraph ${i}. ${'word '.repeat(Math.floor(paragraphLength / 5))}`
+  ).join('\n\n');
+}
 
 describe('tasks', () => {
   describe('content fencing', () => {
@@ -28,6 +44,135 @@ describe('tasks', () => {
     it('leaves content under the cap untouched', () => {
       expect(wasTruncated('short')).toBe(false);
       expect(fenceContent('short')).not.toContain('truncated');
+    });
+  });
+
+  describe('chunkContent', () => {
+    it('returns a single chunk for content that already fits', () => {
+      const { chunks, droppedChars } = chunkContent('short text');
+      expect(chunks).toEqual(['short text']);
+      expect(droppedChars).toBe(0);
+    });
+
+    it('returns no chunks for empty content', () => {
+      expect(chunkContent('   ').chunks).toEqual([]);
+    });
+
+    it('splits long content into chunks that each fit one request', () => {
+      const { chunks, droppedChars } = chunkContent(paragraphs(MAX_CONTENT_CHARS * 3));
+
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(droppedChars).toBe(0);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(MAX_CONTENT_CHARS);
+      }
+    });
+
+    it('splits on paragraph boundaries rather than mid-sentence', () => {
+      const { chunks } = chunkContent(paragraphs(MAX_CONTENT_CHARS * 2));
+
+      // Every chunk should start at the beginning of some paragraph.
+      for (const chunk of chunks) {
+        expect(chunk.trimStart()).toMatch(/^Paragraph \d+\./);
+      }
+    });
+
+    it('loses no content when splitting', () => {
+      const source = paragraphs(MAX_CONTENT_CHARS * 2);
+      const { chunks } = chunkContent(source);
+
+      const rejoined = chunks.join('\n\n').replace(/\s+/g, ' ').trim();
+      const original = source.replace(/\s+/g, ' ').trim();
+      expect(rejoined).toBe(original);
+    });
+
+    it('hard-splits a single paragraph longer than the limit', () => {
+      const oneHugeParagraph = 'x'.repeat(MAX_CONTENT_CHARS * 2 + 10);
+      const { chunks } = chunkContent(oneHugeParagraph);
+
+      expect(chunks.length).toBe(3);
+      for (const chunk of chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(MAX_CONTENT_CHARS);
+      }
+    });
+
+    it('caps the chunk count and reports how much it dropped', () => {
+      const huge = paragraphs(MAX_CONTENT_CHARS * (MAX_CHUNKS + 4));
+      const { chunks, droppedChars } = chunkContent(huge);
+
+      // Bounds the cost of one Summarize click.
+      expect(chunks).toHaveLength(MAX_CHUNKS);
+      expect(droppedChars).toBeGreaterThan(0);
+    });
+
+    it('honours explicit limits', () => {
+      const { chunks, droppedChars } = chunkContent('aaaa\n\nbbbb\n\ncccc', 5, 2);
+      expect(chunks).toEqual(['aaaa', 'bbbb']);
+      expect(droppedChars).toBe(4);
+    });
+  });
+
+  describe('map-reduce prompts', () => {
+    it('tells the map step which section it is reading', () => {
+      const prompt = buildPrompt('summary-chunk', { content: 'text', index: 2, total: 5 });
+
+      expect(prompt.system).toContain('section 3 of 5');
+      expect(prompt.user).toContain('<<<PAGE_CONTENT>>>');
+    });
+
+    it('asks the map step not to write a conclusion', () => {
+      const prompt = buildPrompt('summary-chunk', { content: 'text', index: 0, total: 3 });
+      expect(prompt.system).toMatch(/later sections follow/i);
+    });
+
+    it('does not fence the reduce input, which is our own output', () => {
+      const prompt = buildPrompt('summary-reduce', {
+        notes: 'Section 1:\n- a point',
+        total: 2,
+        title: 'An Article'
+      });
+
+      expect(prompt.user).not.toContain('<<<PAGE_CONTENT>>>');
+      expect(prompt.user).toContain('- a point');
+      expect(prompt.user).toContain('An Article');
+    });
+
+    it('hides the sectioning from the final summary', () => {
+      const prompt = buildPrompt('summary-reduce', { notes: 'notes', total: 3 });
+      expect(prompt.system).toMatch(/do not mention the sections/i);
+    });
+
+    it('applies the requested style and length to the reduce step', () => {
+      const tldr = buildPrompt('summary-reduce', {
+        notes: 'n',
+        total: 2,
+        summaryType: 'tldr',
+        targetLength: 'short'
+      });
+      const long = buildPrompt('summary-reduce', { notes: 'n', total: 2, targetLength: 'long' });
+
+      expect(tldr.system).toContain('TL;DR');
+      expect(long.maxTokens).toBeGreaterThan(tldr.maxTokens);
+    });
+  });
+
+  describe('translation source language', () => {
+    it('names the source language when one is chosen', () => {
+      const prompt = buildPrompt('translation', {
+        text: 'bonjour',
+        sourceLanguage: 'French',
+        targetLanguage: 'English'
+      });
+      expect(prompt.system).toContain('from French');
+    });
+
+    it('omits the source when set to auto', () => {
+      const prompt = buildPrompt('translation', {
+        text: 'bonjour',
+        sourceLanguage: 'auto',
+        targetLanguage: 'English'
+      });
+      expect(prompt.system).not.toContain('from auto');
     });
   });
 

--- a/tests/e2e/extension-loading.spec.js
+++ b/tests/e2e/extension-loading.spec.js
@@ -260,6 +260,45 @@ test.describe('summarization end to end', () => {
     expect(callCount).toBe(response.data.sections + 1);
   });
 
+  test('recovers from a transient rate limit instead of losing the work', async ({
+    context,
+    extensionId
+  }) => {
+    // Chunking turned one request into up to nine; without retries a single
+    // transient 429 would discard every section that already succeeded.
+    let calls = 0;
+    await context.route('https://api.anthropic.com/**', route => {
+      calls += 1;
+      if (calls === 1) {
+        return route.fulfill({
+          status: 429,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: { message: 'slow down' } })
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: [{ type: 'text', text: '- recovered' }] })
+      });
+    });
+
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    await seedPreferences(popup, CONFIGURED_PREFERENCES);
+
+    const response = await popup.evaluate(() =>
+      chrome.runtime.sendMessage({
+        actionType: 'GENERATE_CONTENT_SUMMARY',
+        payload: { content: 'An article worth summarizing.' }
+      })
+    );
+
+    expect(response.success).toBe(true);
+    expect(response.data.summary).toContain('recovered');
+    expect(calls).toBe(2);
+  });
+
   test('a right-click page summary notifies the user', async ({ context, extensionId }) => {
     await stubProvider(context, '- Service workers have no DOM access');
 

--- a/tests/e2e/extension-loading.spec.js
+++ b/tests/e2e/extension-loading.spec.js
@@ -220,6 +220,46 @@ test.describe('summarization end to end', () => {
     expect(requestBodies[0]).toContain('Service workers run separately');
   });
 
+  test('a page too long for one request is summarized in sections', async ({
+    context,
+    extensionId
+  }) => {
+    let callCount = 0;
+    await context.route('https://api.anthropic.com/**', route => {
+      callCount += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ content: [{ type: 'text', text: '- a point' }] })
+      });
+    });
+
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    await seedPreferences(popup, CONFIGURED_PREFERENCES);
+
+    // ~3 chunks worth of real paragraphs.
+    const longPage = Array.from(
+      { length: 80 },
+      (_, i) => `Paragraph ${i}. ${'word '.repeat(180)}`
+    ).join('\n\n');
+
+    const response = await popup.evaluate(
+      content =>
+        chrome.runtime.sendMessage({
+          actionType: 'GENERATE_CONTENT_SUMMARY',
+          payload: { content }
+        }),
+      longPage
+    );
+
+    expect(response.success).toBe(true);
+    expect(response.data.sections).toBeGreaterThan(1);
+    expect(response.data.droppedChars).toBe(0);
+    // One request per section plus the merge.
+    expect(callCount).toBe(response.data.sections + 1);
+  });
+
   test('a right-click page summary notifies the user', async ({ context, extensionId }) => {
     await stubProvider(context, '- Service workers have no DOM access');
 

--- a/tests/integration/extension-workflow.test.js
+++ b/tests/integration/extension-workflow.test.js
@@ -90,6 +90,46 @@ describe('Extension workflow', () => {
       );
     });
 
+    it('summarizes a long page as sections plus one merge, not a truncation', async () => {
+      global.fetch.mockResolvedValue(CLAUDE_REPLY);
+
+      // Three chunks' worth of paragraphs.
+      const longPage = Array.from({ length: 80 }, (_, i) =>
+        `Paragraph ${i}. ${'word '.repeat(180)}`
+      ).join('\n\n');
+
+      const response = await dispatch('GENERATE_CONTENT_SUMMARY', {
+        content: longPage,
+        summaryType: 'key-points'
+      });
+
+      expect(response.success).toBe(true);
+      expect(response.data.sections).toBeGreaterThan(1);
+      expect(response.data.droppedChars).toBe(0);
+      expect(response.data.truncated).toBe(false);
+
+      // One request per section, plus a final merge.
+      expect(global.fetch).toHaveBeenCalledTimes(response.data.sections + 1);
+
+      const bodies = global.fetch.mock.calls.map(call => JSON.parse(call[1].body));
+      const mapCalls = bodies.filter(b => b.system.includes('You are reading section'));
+      const reduceCalls = bodies.filter(b => b.system.includes('You are given ordered notes'));
+      expect(mapCalls).toHaveLength(response.data.sections);
+      expect(reduceCalls).toHaveLength(1);
+
+      // The merge step reads our own notes, so it is not fenced as untrusted.
+      expect(reduceCalls[0].messages[0].content).not.toContain('<<<PAGE_CONTENT>>>');
+    });
+
+    it('still issues exactly one call for a page that fits', async () => {
+      global.fetch.mockResolvedValue(CLAUDE_REPLY);
+
+      const response = await dispatch('GENERATE_CONTENT_SUMMARY', { content: 'A short article.' });
+
+      expect(response.data.sections).toBe(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
     it('rejects empty content before spending an API call', async () => {
       global.fetch.mockResolvedValue(CLAUDE_REPLY);
 

--- a/tests/integration/extension-workflow.test.js
+++ b/tests/integration/extension-workflow.test.js
@@ -34,14 +34,22 @@ const CONFIGURED = {
  * @param {any} payload
  * @returns {Promise<any>}
  */
-function dispatch(actionType, payload) {
+/**
+ * @param {string} actionType
+ * @param {any} payload
+ * @param {number} [timeout]  Raise when the path under test exhausts retries.
+ */
+function dispatch(actionType, payload, timeout = 1000) {
   const handler = chrome.runtime.onMessage.addListener.mock.calls[0][0];
   const sendResponse = vi.fn();
   handler({ actionType, requestId: 'req-1', payload }, { id: 'mock-extension-id' }, sendResponse);
-  return vi.waitFor(() => {
-    expect(sendResponse).toHaveBeenCalled();
-    return sendResponse.mock.calls[0][0];
-  });
+  return vi.waitFor(
+    () => {
+      expect(sendResponse).toHaveBeenCalled();
+      return sendResponse.mock.calls[0][0];
+    },
+    { timeout }
+  );
 }
 
 describe('Extension workflow', () => {
@@ -152,18 +160,46 @@ describe('Extension workflow', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('surfaces a provider failure rather than a plausible fake answer', async () => {
+    it('retries a rate limit, then surfaces it rather than a fake answer', async () => {
       global.fetch.mockResolvedValue({
         ok: false,
         status: 429,
         statusText: 'Too Many Requests',
+        headers: { get: () => null },
         json: vi.fn().mockResolvedValue({ error: { message: 'rate limit exceeded' } })
       });
 
-      const response = await dispatch('GENERATE_CONTENT_SUMMARY', { content: 'article text' });
+      const response = await dispatch(
+        'GENERATE_CONTENT_SUMMARY',
+        { content: 'article text' },
+        10000
+      );
 
       expect(response.success).toBe(false);
       expect(response.error).toContain('rate limit exceeded');
+      // Retried before giving up, rather than failing on the first 429.
+      expect(global.fetch.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    it('recovers from a transient rate limit without the user seeing it', async () => {
+      global.fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: { get: () => null },
+          json: vi.fn().mockResolvedValue({ error: { message: 'slow down' } })
+        })
+        .mockResolvedValue(CLAUDE_REPLY);
+
+      const response = await dispatch(
+        'GENERATE_CONTENT_SUMMARY',
+        { content: 'article text' },
+        10000
+      );
+
+      expect(response.success).toBe(true);
+      expect(response.data.summary).toBe('- point one\n- point two');
     });
   });
 

--- a/tests/popup/rendering.test.js
+++ b/tests/popup/rendering.test.js
@@ -3,7 +3,8 @@ import {
   renderMarkdown,
   escapeHtml,
   countWords,
-  readabilityScore
+  readabilityScore,
+  describeCoverage
 } from '../../scripts/popup-main.js';
 
 describe('popup rendering', () => {
@@ -64,6 +65,27 @@ describe('popup rendering', () => {
       expect(countWords('')).toBe(0);
       expect(countWords('   ')).toBe(0);
       expect(countWords(undefined)).toBe(0);
+    });
+  });
+
+  describe('describeCoverage', () => {
+    // A summary of a huge page that silently used only the first slice is
+    // indistinguishable from a complete one, so coverage is always stated.
+    it('says the whole page for a single-request summary', () => {
+      expect(describeCoverage({ sections: 1, droppedChars: 0 })).toBe('Whole page');
+      expect(describeCoverage({})).toBe('Whole page');
+    });
+
+    it('reports how many sections a long page was split into', () => {
+      expect(describeCoverage({ sections: 5, droppedChars: 0 })).toBe(
+        'Whole page, summarized across 5 sections'
+      );
+    });
+
+    it('says plainly when content was left out', () => {
+      const text = describeCoverage({ sections: 8, droppedChars: 51000 });
+      expect(text).toMatch(/not included/);
+      expect(text).toContain('51,000');
     });
   });
 

--- a/tests/providers/ai-client.test.js
+++ b/tests/providers/ai-client.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AIClient, AIError, PROVIDERS } from '../../providers/ai-client.js';
+import {
+  AIClient,
+  AIError,
+  PROVIDERS,
+  backoffDelay,
+  parseRetryAfter
+} from '../../providers/ai-client.js';
 
 /**
  * @param {any} body
@@ -10,8 +16,14 @@ function mockResponse(body, init = {}) {
     ok: init.ok !== false,
     status: init.status ?? 200,
     statusText: init.statusText ?? 'OK',
+    headers: { get: () => init.retryAfter ?? null },
     json: vi.fn().mockResolvedValue(body)
   };
+}
+
+/** A client that retries without making the test wait for real backoff. */
+function fastClient(overrides = {}) {
+  return new AIClient({ provider: 'anthropic', apiKey: 'k', ...overrides });
 }
 
 const ANTHROPIC_OK = { content: [{ type: 'text', text: '  a summary  ' }] };
@@ -102,6 +114,138 @@ describe('AIClient', () => {
     });
   });
 
+  describe('retrying transient failures', () => {
+    // Chunked summarization turns one request into up to nine. Without retries a
+    // single transient 429 discards every section that already succeeded.
+    it('retries a 429 and returns the eventual success', async () => {
+      global.fetch
+        .mockResolvedValueOnce(mockResponse({ error: { message: 'slow down' } }, { ok: false, status: 429 }))
+        .mockResolvedValueOnce(mockResponse(ANTHROPIC_OK));
+
+      const text = await fastClient().complete('s', 'u');
+
+      expect(text).toBe('a summary');
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries a 529 overloaded response', async () => {
+      global.fetch
+        .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 529 }))
+        .mockResolvedValueOnce(mockResponse(ANTHROPIC_OK));
+
+      await expect(fastClient().complete('s', 'u')).resolves.toBe('a summary');
+    });
+
+    it('retries a network blip', async () => {
+      global.fetch
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce(mockResponse(ANTHROPIC_OK));
+
+      await expect(fastClient().complete('s', 'u')).resolves.toBe('a summary');
+    });
+
+    it('gives up after maxRetries and reports the last error', async () => {
+      global.fetch.mockResolvedValue(
+        mockResponse({ error: { message: 'slow down' } }, { ok: false, status: 429 })
+      );
+
+      await expect(fastClient({ maxRetries: 2 }).complete('s', 'u')).rejects.toMatchObject({
+        code: 'PROVIDER_ERROR'
+      });
+      // The initial attempt plus two retries.
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('can be configured to not retry at all', async () => {
+      global.fetch.mockResolvedValue(mockResponse({}, { ok: false, status: 503 }));
+
+      await expect(fastClient({ maxRetries: 0 }).complete('s', 'u')).rejects.toThrow();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry a bad API key — that wastes quota and hides the real error', async () => {
+      global.fetch.mockResolvedValue(
+        mockResponse({ error: { message: 'invalid x-api-key' } }, { ok: false, status: 401 })
+      );
+
+      await expect(fastClient().complete('s', 'u')).rejects.toMatchObject({ code: 'AUTH_ERROR' });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry a malformed request', async () => {
+      global.fetch.mockResolvedValue(mockResponse({}, { ok: false, status: 400 }));
+
+      await expect(fastClient().complete('s', 'u')).rejects.toThrow();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry a timeout, which may still be running provider side', async () => {
+      const abort = new Error('aborted');
+      abort.name = 'AbortError';
+      global.fetch.mockRejectedValue(abort);
+
+      await expect(fastClient({ timeoutMs: 10 }).complete('s', 'u')).rejects.toMatchObject({
+        code: 'TIMEOUT'
+      });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends an identical body on every attempt', async () => {
+      global.fetch
+        .mockResolvedValueOnce(mockResponse({}, { ok: false, status: 429 }))
+        .mockResolvedValueOnce(mockResponse(ANTHROPIC_OK));
+
+      await fastClient().complete('system', 'user', 400);
+
+      const [first, second] = global.fetch.mock.calls.map(call => call[1].body);
+      expect(first).toBe(second);
+    });
+  });
+
+  describe('backoff', () => {
+    it('grows exponentially and stays bounded', () => {
+      const first = backoffDelay(0);
+      const later = backoffDelay(3);
+
+      expect(later).toBeGreaterThan(first);
+      expect(backoffDelay(50)).toBeLessThanOrEqual(8000 + 500);
+    });
+
+    it('adds jitter so parallel sections do not resynchronise', () => {
+      const samples = new Set(Array.from({ length: 20 }, () => backoffDelay(1)));
+      expect(samples.size).toBeGreaterThan(1);
+    });
+
+    it("prefers the provider's Retry-After over our guess", () => {
+      expect(backoffDelay(0, 2000)).toBe(2000);
+    });
+
+    it('caps even a hostile Retry-After', () => {
+      expect(backoffDelay(0, 999999)).toBeLessThanOrEqual(8000);
+    });
+  });
+
+  describe('parseRetryAfter', () => {
+    it('reads a seconds value', () => {
+      expect(parseRetryAfter('3')).toBe(3000);
+    });
+
+    it('reads an HTTP date', () => {
+      const soon = new Date(Date.now() + 5000).toUTCString();
+      expect(parseRetryAfter(soon)).toBeGreaterThan(1000);
+    });
+
+    it('returns undefined when absent or unparseable', () => {
+      expect(parseRetryAfter(null)).toBeUndefined();
+      expect(parseRetryAfter('')).toBeUndefined();
+      expect(parseRetryAfter('next tuesday')).toBeUndefined();
+    });
+
+    it('never returns a negative delay for a past date', () => {
+      expect(parseRetryAfter(new Date(Date.now() - 60000).toUTCString())).toBe(0);
+    });
+  });
+
   describe('failure modes', () => {
     it('classifies 401 as an auth error', async () => {
       global.fetch.mockResolvedValue(
@@ -112,11 +256,13 @@ describe('AIClient', () => {
       await expect(client.complete('s', 'u')).rejects.toMatchObject({ code: 'AUTH_ERROR' });
     });
 
+    // These assert classification, not retry policy, so retries are off to keep
+    // them fast and to isolate what they cover.
     it('classifies other non-2xx responses as provider errors and keeps the message', async () => {
       global.fetch.mockResolvedValue(
         mockResponse({ error: { message: 'rate limited' } }, { ok: false, status: 429 })
       );
-      const client = new AIClient({ provider: 'openai', apiKey: 'k' });
+      const client = new AIClient({ provider: 'openai', apiKey: 'k', maxRetries: 0 });
 
       await expect(client.complete('s', 'u')).rejects.toMatchObject({
         code: 'PROVIDER_ERROR',
@@ -140,9 +286,10 @@ describe('AIClient', () => {
         ok: false,
         status: 500,
         statusText: 'Internal Server Error',
+        headers: { get: () => null },
         json: vi.fn().mockRejectedValue(new SyntaxError('not json'))
       });
-      const client = new AIClient({ provider: 'anthropic', apiKey: 'k' });
+      const client = new AIClient({ provider: 'anthropic', apiKey: 'k', maxRetries: 0 });
 
       await expect(client.complete('s', 'u')).rejects.toMatchObject({
         message: expect.stringContaining('Internal Server Error')
@@ -151,7 +298,7 @@ describe('AIClient', () => {
 
     it('reports a network failure without masking the cause', async () => {
       global.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
-      const client = new AIClient({ provider: 'anthropic', apiKey: 'k' });
+      const client = new AIClient({ provider: 'anthropic', apiKey: 'k', maxRetries: 0 });
 
       await expect(client.complete('s', 'u')).rejects.toMatchObject({
         code: 'NETWORK_ERROR',


### PR DESCRIPTION
> Stacked on #13 — base is `fix/stub-providers-and-broken-wiring`, so review that first. GitHub will retarget this to `main` automatically when #13 merges.

## Description

Two things: the long-page truncation you flagged as the most visible remaining limitation, and a sweep of controls that looked functional but weren't.

### Chunked summarization

Pages over 24,000 characters were cut off at the limit. Honest, but not much use on a long article.

`chunkContent()` now splits on blank lines so a boundary lands between paragraphs rather than mid-sentence, each section is summarized in its own request, and the notes are merged into one summary.

Three decisions worth flagging for review:

- **The map prompt asks for retained detail, not a polished summary.** Its output feeds the merge step, and compressing twice loses the specifics the final summary needs.
- **The merge input is not fenced.** Page text is fenced as untrusted; partial summaries are our own output, so fencing them would be cargo-culting the mitigation.
- **Sections run concurrently.** Nine sequential requests take most of a minute and this is a foreground popup. A rate-limit rejection on any section fails the whole summary with the provider's own message — a partial summary presented as complete would be worse.

Capped at **8 sections (9 requests, ~192,000 characters)** so one click can't run away with an API budget. Coverage is always reported:

| Shown | Meaning |
| --- | --- |
| `Whole page` | Fit in one request |
| `Whole page, summarized across 4 sections` | Split, nothing dropped |
| `Very long page — summarized the first 8 sections, 51,000 characters not included` | Hit the cap |

### Settings that did nothing

While verifying the above I found the popup never read saved preferences at all — summary style, length, target language, and theme were stored by the options page and ignored. Changing any of them appeared to do nothing. Theme also reset on every popup open.

Translation ignored the "From" selector; it was read only by the swap button and never sent to the provider.

Entity extraction was implemented in the background and reachable by message, but no button called it. Added the Analyze card.

Removed four controls with no handler behind them: **Save Summary** (hidden and unreachable — summaries already save to history on generation), **Speak**, **Create Bookmark**, and **Preserve formatting**. A button that silently does nothing is worse than no button.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update
- [x] Test coverage improvement

## Testing

```
104 passed  (vitest, was 84)
 12 passed  (playwright, real Chrome with extension loaded, was 11)
  0 errors  (eslint)
  0 errors  (tsc --noEmit)
  4 bundles (rollup)
```

New coverage:

- **Chunking**: paragraph-boundary splitting, no content lost when rejoined, hard-split of a single oversized paragraph, the section cap and its dropped-character count, and explicit-limit behaviour.
- **Map-reduce wiring** (integration): a long page issues exactly N section calls plus one merge, the merge input is not fenced, and a short page still issues exactly one call.
- **Real browser** (e2e): a long page is genuinely summarized in sections with the request count verified through the actual extension.
- **Coverage reporting**: the three states above, so a partially-summarized page can never look complete.

One test caught a real mistake in my own test code — the first filter matched `'section'`, which also appears in the reduce prompt's "do not mention the sections", so it counted 5 map calls instead of 4. Tightened to match distinctive phrases.

## Manual Testing

Unchanged from #13: Chrome grants `activeTab` only on a real toolbar-icon click, which Playwright can't perform. Worth loading the repo root at `chrome://extensions` with a real key and summarizing one genuinely long article — that's the only way to see multi-section latency and real token cost.

## Known Limitations

- Chat, translation, and the analysis actions still use a single request and truncate at 24,000 characters. Q&A over a long page needs retrieval, not map-reduce, so it's deliberately out of scope here.
- Pages beyond ~192,000 characters are summarized up to the cap only.

## Follow-ups

- Chrome built-in AI via an offscreen document.
- Multi-tab comparison.
- Retrieval-backed Q&A for long pages.
