### PR TITLE
fix(test): make the coverage gate real, and cover the three untested DOM controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the GenAI Browser Tool project will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **The coverage gate enforced nothing.** Thresholds were nested under a
+  `global` key — the Jest shape. Vitest reads them flat and treated `global` as
+  a glob matching no file, so `test:coverage` reported success while the suite
+  sat below the 70% it claimed to require. Now flat, enforced, and set to the
+  level the suite actually holds.
+- Coverage now reports on every shipped source file (`all: true`). Files no test
+  imported were previously absent from the table entirely, which read as "fine"
+  rather than "uncovered".
+
+### Added
+- Unit tests for the three DOM controllers that had no unit coverage at all:
+  `content.js` 0% → 96%, `options.js` 0% → 99%, `scripts/popup-main.js`
+  33% → 84%. Overall 63% → 84%.
+- A regression guard asserting `content.js` stays free of ESM syntax. A
+  declarative MV3 content script is a *classic* script, so an `export` there is
+  a parse error that silently stops all extraction — caught previously only by
+  a full browser launch, now in a millisecond.
+- Tests for `utils/logger.js` level filtering (0 → 100%).
+
 ## [5.1.0]
 
 ### Added

--- a/content.js
+++ b/content.js
@@ -7,6 +7,18 @@
  * that talks to a network.
  */
 
+/**
+ * NOTE: this file must contain no `import` or `export` statements.
+ *
+ * A declarative MV3 content script is loaded as a *classic* script, where ESM
+ * syntax is a parse error — the script silently fails to load and every
+ * extraction returns "Receiving end does not exist". Chrome offers no
+ * `"type": "module"` for `content_scripts`.
+ *
+ * A file with no ESM syntax is still importable by Vitest, so the test suite
+ * imports this module for its side effects and picks the class off `globalThis`
+ * (see the bottom of this file).
+ */
 class PageContentExtractor {
   constructor() {
     chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
@@ -139,4 +151,11 @@ class PageContentExtractor {
   }
 }
 
-new PageContentExtractor();
+// Exposed for the test suite, which cannot `import` from a classic script.
+/** @type {any} */ (globalThis).PageContentExtractor = PageContentExtractor;
+
+// Guarded so importing this file in a test does not register a listener against
+// a mock `chrome` with no real message channel.
+if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.onMessage) {
+  new PageContentExtractor();
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -343,6 +343,41 @@ test('should load extension', async ({ page, context }) => {
 - **Chrome DevTools**: Performance profiling
 - **Coverage Reports**: Code coverage analysis
 
+## Content script constraint
+
+`content.js` **must contain no `import` or `export` statements.**
+
+A declarative MV3 content script is loaded as a *classic* script, where ESM
+syntax is a parse error. Chrome offers no `"type": "module"` for
+`content_scripts`, so the failure is silent: the script never loads, and every
+extraction returns `Receiving end does not exist`. Unit tests keep passing,
+because Vitest imports the file happily.
+
+It therefore exposes its class on `globalThis` for the test suite instead of
+exporting it. `tests/content/extraction.test.js` has a guard asserting the file
+stays ESM-free, so this is caught in a millisecond rather than by a full browser
+launch.
+
+`background.js` is a module (`"type": "module"` in the manifest's `background`
+block), and `popup-main.js` / `options.js` are loaded via
+`<script type="module">`, so those may use imports and exports freely.
+
+## Test layout
+
+| Path | Runner | Covers |
+| --- | --- | --- |
+| `tests/core`, `tests/providers`, `tests/utils` | Vitest | Pure logic: prompts, chunking, retry, config |
+| `tests/content`, `tests/options`, `tests/popup` | Vitest + jsdom | DOM controllers against a fixture |
+| `tests/integration` | Vitest | The background message router end to end, `fetch` mocked |
+| `tests/e2e` | Playwright | Real Chrome, extension loaded unpacked |
+
+Coverage thresholds are enforced (`npm run test:coverage` exits non-zero on a
+breach) and set to the level the suite currently holds. Raise them as coverage
+improves; do not lower them to go green.
+
+Note the numbers only reflect the Vitest run — Playwright drives a separate
+browser process and contributes nothing to them.
+
 ## Build System
 
 **No build step is required for development.** Load the repository root as an

--- a/options.js
+++ b/options.js
@@ -9,7 +9,7 @@
 import { ConfigurationManager } from './core/configuration-manager.js';
 import { PROVIDER_IDS } from './providers/ai-client.js';
 
-class OptionsPage {
+export class OptionsPage {
   constructor() {
     this.configManager = new ConfigurationManager();
     this.settings = this.configManager.defaultSettings;

--- a/scripts/popup-main.js
+++ b/scripts/popup-main.js
@@ -7,7 +7,7 @@
  * had seven handlers that only displayed "Saved"/"Exported" and did nothing.
  */
 
-class PopupInterface {
+export class PopupInterface {
   constructor() {
     /** @type {any} */
     this.pageContent = null;

--- a/tests/content/extraction.test.js
+++ b/tests/content/extraction.test.js
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// content.js is a classic script (MV3 declarative content scripts cannot be
+// modules), so it exposes the class on globalThis rather than exporting it.
+// Importing for side effects is what makes it available here.
+import '../../content.js';
+
+/** @type {any} */
+const PageContentExtractor = globalThis.PageContentExtractor;
+
+/**
+ * Unit coverage for the content script's DOM reading.
+ *
+ * The e2e suite proves extraction works in real Chrome on one fixture page;
+ * these cover the edge cases that are tedious to stage in a browser — missing
+ * containers, malformed markup, hostile URLs.
+ *
+ * Note: jsdom does not implement `innerText`, so these exercise the
+ * `textContent` fallback in getMainText(). Real Chrome takes the `innerText`
+ * path, which additionally drops hidden elements — the e2e test covers that.
+ */
+
+/** @param {string} html */
+function setBody(html) {
+  document.body.innerHTML = html;
+}
+
+describe('PageContentExtractor', () => {
+  /** @type {any} */
+  let extractor;
+
+  it('is loadable as a classic script, with no ESM syntax', async () => {
+    // Regression guard: adding `export` here is a parse error in a real content
+    // script, so extraction silently stops working everywhere. Only the
+    // browser e2e suite catches that, and it costs a full browser launch.
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    // Resolved from cwd: the jsdom environment gives import.meta.url an http
+    // base, which readFileSync rejects.
+    const source = readFileSync(resolve(process.cwd(), 'content.js'), 'utf8');
+
+    expect(source).not.toMatch(/^\s*export\s/m);
+    expect(source).not.toMatch(/^\s*import\s/m);
+  });
+
+  beforeEach(() => {
+    extractor = new PageContentExtractor();
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    document.title = '';
+  });
+
+  describe('getMainText', () => {
+    it('prefers <article> over the whole body', () => {
+      setBody(`
+        <nav>Site navigation</nav>
+        <article><p>The actual article body.</p></article>
+        <footer>Legal boilerplate</footer>
+      `);
+
+      const text = extractor.getMainText();
+      expect(text).toContain('The actual article body.');
+      expect(text).not.toContain('Site navigation');
+      expect(text).not.toContain('Legal boilerplate');
+    });
+
+    it('falls through the selector list to [role=main] then <main>', () => {
+      setBody('<div role="main"><p>Role main content.</p></div>');
+      expect(extractor.getMainText()).toContain('Role main content.');
+
+      setBody('<main><p>Main element content.</p></main>');
+      expect(extractor.getMainText()).toContain('Main element content.');
+    });
+
+    it('falls back to body when no content container exists', () => {
+      setBody('<div><p>Loose paragraph.</p></div>');
+      expect(extractor.getMainText()).toContain('Loose paragraph.');
+    });
+
+    it('strips scripts, styles, ads, sidebars and comments', () => {
+      setBody(`
+        <article>
+          <p>Keep this.</p>
+          <script>window.tracker = 1;</script>
+          <style>.x { color: red }</style>
+          <div class="ad">Buy now</div>
+          <div class="sidebar">Related links</div>
+          <div class="comments">First!</div>
+          <aside>Aside content</aside>
+        </article>
+      `);
+
+      const text = extractor.getMainText();
+      expect(text).toContain('Keep this.');
+      for (const noise of [
+        'window.tracker',
+        'color: red',
+        'Buy now',
+        'Related links',
+        'First!',
+        'Aside content'
+      ]) {
+        expect(text).not.toContain(noise);
+      }
+    });
+
+    it('does not mutate the live page while stripping', () => {
+      // Extraction works on a clone. Removing nodes from the real document
+      // would visibly break the page the user is reading.
+      setBody('<article><p>Body</p><script>var a = 1;</script></article>');
+
+      extractor.getMainText();
+
+      expect(document.querySelector('script')).not.toBeNull();
+      expect(document.querySelector('article p')).not.toBeNull();
+    });
+
+    it('returns an empty string for an empty document', () => {
+      setBody('');
+      expect(extractor.getMainText()).toBe('');
+    });
+  });
+
+  describe('getPageTitle', () => {
+    it('uses document.title when present', () => {
+      document.title = 'Real Title';
+      expect(extractor.getPageTitle()).toBe('Real Title');
+    });
+
+    it('falls back to the first h1', () => {
+      document.title = '';
+      setBody('<h1>  Heading Title  </h1>');
+      expect(extractor.getPageTitle()).toBe('Heading Title');
+    });
+
+    it('falls back to a placeholder when there is nothing', () => {
+      document.title = '';
+      setBody('');
+      expect(extractor.getPageTitle()).toBe('Untitled Page');
+    });
+  });
+
+  describe('extractHeadings', () => {
+    it('records level and text in document order', () => {
+      setBody('<h1>One</h1><h3>Three</h3><h2>Two</h2>');
+
+      expect(extractor.extractHeadings()).toEqual([
+        { level: 1, text: 'One' },
+        { level: 3, text: 'Three' },
+        { level: 2, text: 'Two' }
+      ]);
+    });
+
+    it('drops headings with no text', () => {
+      setBody('<h1>Real</h1><h2></h2><h3>   </h3>');
+      expect(extractor.extractHeadings()).toEqual([{ level: 1, text: 'Real' }]);
+    });
+  });
+
+  describe('getPageMetadata', () => {
+    it('reads both name and property meta tags', () => {
+      document.head.innerHTML = `
+        <meta name="description" content="A description">
+        <meta property="og:title" content="Open Graph Title">
+      `;
+
+      expect(extractor.getPageMetadata()).toEqual({
+        description: 'A description',
+        'og:title': 'Open Graph Title'
+      });
+    });
+
+    it('skips meta tags with no name or no content', () => {
+      document.head.innerHTML = `
+        <meta content="orphan content">
+        <meta name="empty">
+        <meta charset="utf-8">
+      `;
+      expect(extractor.getPageMetadata()).toEqual({});
+    });
+  });
+
+  describe('extractLinks', () => {
+    it('keeps http(s) links and marks external ones', () => {
+      setBody(`
+        <a href="https://example.com/other">External</a>
+        <a href="/relative">Relative</a>
+      `);
+
+      const links = extractor.extractLinks();
+      const external = links.find(l => l.text === 'External');
+      const relative = links.find(l => l.text === 'Relative');
+
+      expect(external?.isExternal).toBe(true);
+      // jsdom serves pages from localhost, so a relative link is same-origin.
+      expect(relative?.isExternal).toBe(false);
+    });
+
+    it('drops javascript: and mailto: links', () => {
+      setBody(`
+        <a href="javascript:alert(1)">Bad</a>
+        <a href="mailto:a@b.com">Mail</a>
+        <a href="https://example.com/ok">Good</a>
+      `);
+
+      const hrefs = extractor.extractLinks().map(l => l.href);
+      expect(hrefs).toEqual(['https://example.com/ok']);
+    });
+
+    it('ignores anchors without href', () => {
+      setBody('<a>No href</a>');
+      expect(extractor.extractLinks()).toEqual([]);
+    });
+  });
+
+  describe('extractImages', () => {
+    it('drops inline data URIs, which are not useful to report', () => {
+      setBody(`
+        <img src="https://example.com/a.png" alt="A picture">
+        <img src="data:image/png;base64,iVBORw0KGgo=" alt="Inline">
+      `);
+
+      const images = extractor.extractImages();
+      expect(images).toHaveLength(1);
+      expect(images[0].alt).toBe('A picture');
+    });
+  });
+
+  describe('extractSelectedText', () => {
+    it('returns null when nothing is selected', () => {
+      setBody('<p>Some text</p>');
+      expect(extractor.extractSelectedText()).toBeNull();
+    });
+  });
+
+  describe('handleMessage', () => {
+    it('routes each supported action', async () => {
+      document.title = 'Routing';
+      setBody('<article><p>Content</p></article>');
+
+      await expect(extractor.handleMessage({ action: 'extractContent' }))
+        .resolves.toMatchObject({ title: 'Routing' });
+      await expect(extractor.handleMessage({ action: 'extractLinks' }))
+        .resolves.toEqual([]);
+      await expect(extractor.handleMessage({ action: 'getPageMetadata' }))
+        .resolves.toEqual({});
+      await expect(extractor.handleMessage({ action: 'extractImages' }))
+        .resolves.toEqual([]);
+    });
+
+    it('rejects an unknown action instead of returning nothing', async () => {
+      await expect(extractor.handleMessage({ action: 'deleteEverything' }))
+        .rejects.toThrow(/Unknown action/);
+    });
+
+    it('reports a language of unknown rather than guessing English', () => {
+      document.documentElement.removeAttribute('lang');
+      expect(extractor.extractPageContent().language).toBe('unknown');
+    });
+  });
+});

--- a/tests/options/options-page.test.js
+++ b/tests/options/options-page.test.js
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OptionsPage } from '../../options.js';
+
+/**
+ * Unit coverage for the settings form.
+ *
+ * The e2e suite proves one key round-trips through real Chrome storage. These
+ * cover the rest of the form: model overrides, feature toggles, provider
+ * selection, reset, and the section navigation.
+ */
+
+const FIXTURE = `
+  <button class="nav-item active" data-section="ai-providers"></button>
+  <button class="nav-item" data-section="features"></button>
+  <section class="settings-section active" id="ai-providers-section"></section>
+  <section class="settings-section" id="features-section"></section>
+
+  <input type="radio" name="primary-provider" value="anthropic">
+  <input type="radio" name="primary-provider" value="openai">
+  <input type="radio" name="primary-provider" value="gemini">
+
+  <input type="password" id="anthropic-key">
+  <input type="password" id="openai-key">
+  <input type="password" id="gemini-key">
+  <input type="text" id="anthropic-model">
+  <input type="text" id="openai-model">
+  <input type="text" id="gemini-model">
+
+  <select id="summary-type-pref"><option value="key-points">k</option><option value="tldr">t</option></select>
+  <select id="summary-length-pref"><option value="medium">m</option><option value="long">l</option></select>
+  <input type="checkbox" id="contextMenus">
+  <input type="checkbox" id="notifications">
+  <input type="checkbox" id="saveHistory">
+
+  <button id="reset-settings"></button>
+  <div id="save-indicator"><span class="text"></span></div>
+`;
+
+/** @param {any} stored */
+async function createPage(stored) {
+  document.body.innerHTML = FIXTURE;
+  chrome.storage.sync.get.mockResolvedValue(stored ? { user_preferences: stored } : {});
+
+  const page = new OptionsPage();
+  // initialize() is async and started by the constructor: it awaits storage,
+  // then renders, then attaches listeners. Waiting on a rendered outcome is
+  // more reliable than counting microtask turns.
+  await vi.waitFor(() =>
+    expect(document.querySelector('input[name="primary-provider"]:checked')).not.toBeNull()
+  );
+  return page;
+}
+
+/** The preferences object written by the most recent storage.sync.set call. */
+function lastWrite() {
+  const calls = chrome.storage.sync.set.mock.calls;
+  return calls[calls.length - 1][0].user_preferences;
+}
+
+/** @param {string} id @param {string} value */
+async function change(id, value) {
+  const el = /** @type {HTMLInputElement} */ (document.getElementById(id));
+  el.value = value;
+  el.dispatchEvent(new window.Event('change', { bubbles: true }));
+  await vi.waitFor(() => expect(chrome.storage.sync.set).toHaveBeenCalled());
+}
+
+describe('OptionsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chrome.storage.sync.get.mockResolvedValue({});
+    chrome.storage.sync.set.mockResolvedValue(undefined);
+  });
+
+  describe('rendering stored settings', () => {
+    it('shows saved keys, models, and toggles', async () => {
+      await createPage({
+        preferredProvider: 'openai',
+        apiKeys: { openai: 'sk-stored', anthropic: 'sk-ant-stored' },
+        models: { openai: 'gpt-custom' },
+        summaryType: 'tldr',
+        summaryLength: 'long',
+        features: { contextMenus: false, notifications: true, saveHistory: true }
+      });
+
+      expect(/** @type {HTMLInputElement} */ (document.getElementById('openai-key')).value)
+        .toBe('sk-stored');
+      expect(/** @type {HTMLInputElement} */ (document.getElementById('anthropic-key')).value)
+        .toBe('sk-ant-stored');
+      expect(/** @type {HTMLInputElement} */ (document.getElementById('openai-model')).value)
+        .toBe('gpt-custom');
+      expect(
+        /** @type {HTMLInputElement} */ (
+          document.querySelector('input[name="primary-provider"][value="openai"]')
+        ).checked
+      ).toBe(true);
+      expect(/** @type {HTMLInputElement} */ (document.getElementById('contextMenus')).checked)
+        .toBe(false);
+      expect(/** @type {HTMLInputElement} */ (document.getElementById('notifications')).checked)
+        .toBe(true);
+    });
+
+    it('renders defaults with nothing stored, and does not throw', async () => {
+      // The v4 page threw a TypeError here because defaults had no `features`.
+      await createPage(null);
+
+      expect(
+        /** @type {HTMLInputElement} */ (
+          document.querySelector('input[name="primary-provider"][value="anthropic"]')
+        ).checked
+      ).toBe(true);
+      expect(/** @type {HTMLInputElement} */ (document.getElementById('anthropic-key')).value)
+        .toBe('');
+    });
+
+    it('renders a preferences object written by an older version', async () => {
+      await createPage({ preferredProvider: 'openai' });
+
+      expect(/** @type {HTMLInputElement} */ (document.getElementById('openai-key')).value).toBe('');
+    });
+  });
+
+  describe('saving changes', () => {
+    it('stores an API key under the provider it belongs to', async () => {
+      await createPage(null);
+      await change('anthropic-key', 'sk-ant-typed');
+
+      expect(lastWrite().apiKeys.anthropic).toBe('sk-ant-typed');
+    });
+
+    it('trims whitespace pasted around a key', async () => {
+      await createPage(null);
+      await change('openai-key', '  sk-padded  ');
+
+      expect(lastWrite().apiKeys.openai).toBe('sk-padded');
+    });
+
+    it('stores a model override separately from the key', async () => {
+      await createPage(null);
+      await change('gemini-model', 'gemini-custom');
+
+      const written = lastWrite();
+      expect(written.models.gemini).toBe('gemini-custom');
+      expect(written.apiKeys.gemini).toBeUndefined();
+    });
+
+    it('does not clobber another provider key when one changes', async () => {
+      await createPage({ apiKeys: { openai: 'sk-existing' } });
+      await change('anthropic-key', 'sk-new');
+
+      const written = lastWrite();
+      expect(written.apiKeys.openai).toBe('sk-existing');
+      expect(written.apiKeys.anthropic).toBe('sk-new');
+    });
+
+    it('stores the selected provider', async () => {
+      await createPage(null);
+
+      const radio = /** @type {HTMLInputElement} */ (
+        document.querySelector('input[name="primary-provider"][value="gemini"]')
+      );
+      radio.checked = true;
+      radio.dispatchEvent(new window.Event('change', { bubbles: true }));
+      await vi.waitFor(() => expect(chrome.storage.sync.set).toHaveBeenCalled());
+
+      expect(lastWrite().preferredProvider).toBe('gemini');
+    });
+
+    it('stores summary preferences', async () => {
+      await createPage(null);
+      await change('summary-type-pref', 'tldr');
+
+      expect(lastWrite().summaryType).toBe('tldr');
+    });
+
+    it('stores a feature toggle by its element id', async () => {
+      await createPage(null);
+
+      const checkbox = /** @type {HTMLInputElement} */ (document.getElementById('notifications'));
+      checkbox.checked = false;
+      checkbox.dispatchEvent(new window.Event('change', { bubbles: true }));
+      await vi.waitFor(() => expect(chrome.storage.sync.set).toHaveBeenCalled());
+
+      expect(lastWrite().features.notifications).toBe(false);
+    });
+
+    it('confirms the save in the UI', async () => {
+      await createPage(null);
+      await change('anthropic-key', 'sk-x');
+
+      expect(document.getElementById('save-indicator')?.classList.contains('visible')).toBe(true);
+    });
+
+    it('tells the user when a save fails instead of showing success', async () => {
+      await createPage(null);
+      chrome.storage.sync.set.mockRejectedValue(new Error('QUOTA_BYTES exceeded'));
+
+      const el = /** @type {HTMLInputElement} */ (document.getElementById('anthropic-key'));
+      el.value = 'sk-x';
+      el.dispatchEvent(new window.Event('change', { bubbles: true }));
+
+      await vi.waitFor(() =>
+        expect(document.querySelector('#save-indicator .text')?.textContent)
+          .toMatch(/Could not save/)
+      );
+    });
+  });
+
+  describe('reset', () => {
+    // options.js calls bare `confirm(...)`, which resolves on globalThis.
+    // tests/setup.js builds its own JSDOM for `window`/`document`, so assigning
+    // `window.confirm` would patch a different object than the one under test.
+    it('writes defaults when confirmed', async () => {
+      const page = await createPage({ apiKeys: { openai: 'sk-existing' } });
+      vi.stubGlobal('confirm', vi.fn(() => true));
+
+      await page.resetSettings();
+
+      expect(lastWrite().apiKeys).toEqual({});
+      vi.unstubAllGlobals();
+    });
+
+    it('does nothing when cancelled', async () => {
+      const page = await createPage({ apiKeys: { openai: 'sk-existing' } });
+      vi.stubGlobal('confirm', vi.fn(() => false));
+      vi.clearAllMocks();
+
+      await page.resetSettings();
+
+      expect(chrome.storage.sync.set).not.toHaveBeenCalled();
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe('section navigation', () => {
+    it('moves the active class to the clicked section', async () => {
+      await createPage(null);
+
+      const featuresNav = /** @type {HTMLElement} */ (
+        document.querySelector('.nav-item[data-section="features"]')
+      );
+      featuresNav.click();
+
+      expect(featuresNav.classList.contains('active')).toBe(true);
+      expect(document.getElementById('features-section')?.classList.contains('active')).toBe(true);
+      expect(document.getElementById('ai-providers-section')?.classList.contains('active'))
+        .toBe(false);
+    });
+  });
+});

--- a/tests/popup/controller.test.js
+++ b/tests/popup/controller.test.js
@@ -1,0 +1,433 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PopupInterface } from '../../scripts/popup-main.js';
+
+/**
+ * Unit coverage for the popup controller.
+ *
+ * Only the pure helpers were tested before, leaving the controller itself — the
+ * part that decides whether a page is readable and what the user is told —
+ * uncovered. That includes the `activeTab` path Playwright cannot reach,
+ * because Chrome grants that permission only on a real toolbar-icon click.
+ *
+ * What is testable here is our half of that contract: how the controller
+ * behaves when `tab.url` is present, and when it is not because the permission
+ * was never granted. The grant itself is Chrome's behaviour, not ours.
+ */
+
+/** Minimal DOM carrying the ids the controller touches. */
+const FIXTURE = `
+  <span id="current-page-title"></span>
+  <div id="page-info"></div>
+  <span id="provider-indicator"></span>
+  <span id="provider-name"></span>
+
+  <select id="summary-type"><option value="key-points">k</option><option value="tldr">t</option></select>
+  <input type="radio" name="summary-length" value="short">
+  <input type="radio" name="summary-length" value="medium">
+  <input type="radio" name="summary-length" value="long">
+  <button id="generate-summary-btn"></button>
+  <div id="summary-results" style="display:none">
+    <div id="summary-content"></div>
+    <span id="summary-provider"></span>
+    <span id="summary-confidence"></span>
+  </div>
+
+  <div id="chat-history"></div>
+  <textarea id="chat-input"></textarea>
+
+  <select id="source-language"><option value="auto">auto</option><option value="French">fr</option></select>
+  <select id="target-language"><option value="en">en</option><option value="de">de</option></select>
+  <input type="checkbox" id="translate-page" checked>
+  <div id="translation-results" style="display:none">
+    <div id="translation-content"></div>
+    <span id="detected-language"></span>
+    <span id="translation-confidence"></span>
+  </div>
+
+  <div id="sentiment-result"></div>
+  <div id="tags-result"></div>
+  <div id="readability-result"></div>
+
+  <button id="theme-toggle"></button>
+  <div id="toast-container"></div>
+  <div id="loading-overlay" style="display:none"><span id="loading-text"></span></div>
+`;
+
+/**
+ * Build a controller with its constructor-time initialize() already settled.
+ *
+ * @param {{ tab?: any, responses?: Record<string, any> }} [options]
+ */
+async function createPopup({ tab, responses = {} } = {}) {
+  document.body.innerHTML = FIXTURE;
+  document.body.className = '';
+
+  chrome.tabs.query.mockResolvedValue(tab ? [tab] : []);
+  chrome.runtime.sendMessage.mockImplementation(async (/** @type {any} */ message) => {
+    if (message.actionType in responses) return responses[message.actionType];
+    return { success: false, error: 'not stubbed' };
+  });
+
+  const popup = new PopupInterface();
+  // Let the constructor's async initialize() run to completion.
+  await vi.waitFor(() => expect(chrome.tabs.query).toHaveBeenCalled());
+  await Promise.resolve();
+  return popup;
+}
+
+const HTTP_TAB = { id: 7, url: 'https://example.com/article', title: 'An Article' };
+
+const PAGE_CONTENT = {
+  success: true,
+  data: {
+    title: 'An Article',
+    url: 'https://example.com/article',
+    mainText: 'The article body has several words in it.',
+    headings: [{ level: 1, text: 'An Article' }],
+    language: 'en'
+  }
+};
+
+/** @param {string} id */
+const text = id => document.getElementById(id)?.textContent ?? '';
+
+describe('PopupInterface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chrome.tabs.query.mockResolvedValue([]);
+    chrome.runtime.sendMessage.mockResolvedValue({ success: false, error: 'not stubbed' });
+  });
+
+  describe('deciding whether a page can be read', () => {
+    it('reads a normal http page', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+
+      expect(popup.pageContent.mainText).toContain('The article body');
+      expect(text('current-page-title')).toBe('An Article');
+      // Word count, not character count.
+      expect(document.getElementById('page-info')?.title).toContain('8 words');
+    });
+
+    it('refuses a chrome:// page without calling the background', async () => {
+      await createPopup({ tab: { id: 1, url: 'chrome://extensions', title: 'Extensions' } });
+
+      expect(text('current-page-title')).toMatch(/cannot be read/i);
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ actionType: 'EXTRACT_PAGE_CONTENT' })
+      );
+    });
+
+    it('treats a tab with no readable url as unreadable', async () => {
+      // This is what the popup sees when activeTab was never granted: the tab
+      // object exists and has an id, but `url` is withheld by Chrome. Playwright
+      // cannot produce the granted case, so this pins the ungranted one.
+      await createPopup({ tab: { id: 3 } });
+
+      expect(text('current-page-title')).toMatch(/cannot be read/i);
+    });
+
+    it('handles there being no active tab at all', async () => {
+      await createPopup({ tab: undefined });
+      expect(text('current-page-title')).toMatch(/cannot be read/i);
+    });
+
+    it('surfaces a background extraction failure verbatim', async () => {
+      await createPopup({
+        tab: HTTP_TAB,
+        responses: {
+          EXTRACT_PAGE_CONTENT: {
+            success: false,
+            error: 'Cannot read this page (Receiving end does not exist).'
+          }
+        }
+      });
+
+      expect(document.getElementById('page-info')?.title).toContain('Receiving end does not exist');
+    });
+  });
+
+  describe('applying saved preferences', () => {
+    it('seeds the controls from stored settings', async () => {
+      await createPopup({
+        tab: HTTP_TAB,
+        responses: {
+          GET_USER_PREFERENCES: {
+            success: true,
+            data: {
+              summaryType: 'tldr',
+              summaryLength: 'long',
+              targetLanguage: 'de',
+              theme: 'dark',
+              features: {}
+            }
+          },
+          EXTRACT_PAGE_CONTENT: PAGE_CONTENT
+        }
+      });
+
+      expect(/** @type {HTMLSelectElement} */ (document.getElementById('summary-type')).value)
+        .toBe('tldr');
+      expect(/** @type {HTMLSelectElement} */ (document.getElementById('target-language')).value)
+        .toBe('de');
+      expect(
+        /** @type {HTMLInputElement} */ (
+          document.querySelector('input[name="summary-length"][value="long"]')
+        ).checked
+      ).toBe(true);
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+    });
+
+    it('leaves defaults alone when preferences cannot be read', async () => {
+      await createPopup({ tab: HTTP_TAB });
+
+      expect(document.body.classList.contains('dark-theme')).toBe(false);
+    });
+
+    it('persists a theme toggle instead of losing it on close', async () => {
+      const popup = await createPopup({ tab: HTTP_TAB });
+      chrome.runtime.sendMessage.mockResolvedValue({ success: true, data: {} });
+
+      await popup.toggleTheme();
+
+      expect(document.body.classList.contains('dark-theme')).toBe(true);
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: 'UPDATE_USER_PREFERENCES',
+          payload: { theme: 'dark' }
+        })
+      );
+    });
+  });
+
+  describe('provider status', () => {
+    it('warns when the selected provider has no key', async () => {
+      await createPopup({
+        tab: HTTP_TAB,
+        responses: {
+          GET_PROVIDER_STATUS: { success: true, data: { provider: 'anthropic', configured: false } }
+        }
+      });
+
+      expect(text('provider-name')).toMatch(/no API key/i);
+      expect(document.getElementById('toast-container')?.textContent)
+        .toMatch(/Add an API key/i);
+    });
+
+    it('shows the provider as ready when a key is set', async () => {
+      await createPopup({
+        tab: HTTP_TAB,
+        responses: {
+          GET_PROVIDER_STATUS: { success: true, data: { provider: 'openai', configured: true } }
+        }
+      });
+
+      expect(text('provider-name')).toBe('openai');
+      expect(document.getElementById('provider-indicator')?.classList.contains('active')).toBe(true);
+    });
+  });
+
+  describe('summarizing', () => {
+    it('refuses to summarize with no page content', async () => {
+      const popup = await createPopup({ tab: undefined });
+
+      await popup.generateSummary();
+
+      expect(document.getElementById('toast-container')?.textContent)
+        .toMatch(/No readable page content/i);
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ actionType: 'GENERATE_CONTENT_SUMMARY' })
+      );
+    });
+
+    it('renders the summary with provider and coverage', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: true,
+        data: {
+          summary: '- first point',
+          provider: 'anthropic',
+          model: 'claude-opus-5',
+          sections: 3,
+          droppedChars: 0
+        }
+      });
+
+      await popup.generateSummary();
+
+      expect(document.getElementById('summary-content')?.innerHTML).toContain('first point');
+      expect(text('summary-provider')).toBe('anthropic · claude-opus-5');
+      expect(text('summary-confidence')).toContain('3 sections');
+      expect(document.getElementById('summary-results')?.style.display).toBe('block');
+    });
+
+    it('reports a failed summary as a toast rather than blank output', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      chrome.runtime.sendMessage.mockResolvedValue({ success: false, error: 'rate limit exceeded' });
+
+      await popup.generateSummary();
+
+      expect(document.getElementById('toast-container')?.textContent)
+        .toContain('rate limit exceeded');
+      expect(document.getElementById('summary-content')?.innerHTML).toBe('');
+    });
+  });
+
+  describe('chat', () => {
+    it('notes once that a long page is answered from part of it', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: true,
+        data: { answer: 'An answer.', truncated: true }
+      });
+
+      const input = /** @type {HTMLTextAreaElement} */ (document.getElementById('chat-input'));
+
+      input.value = 'First question?';
+      await popup.sendChatMessage();
+      input.value = 'Second question?';
+      await popup.sendChatMessage();
+
+      const notices = document.getElementById('chat-history')?.textContent?.match(/only its first section/g);
+      expect(notices).toHaveLength(1);
+    });
+
+    it('says nothing extra when the whole page fit', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: true,
+        data: { answer: 'An answer.', truncated: false }
+      });
+
+      /** @type {HTMLTextAreaElement} */ (document.getElementById('chat-input')).value = 'Q?';
+      await popup.sendChatMessage();
+
+      expect(document.getElementById('chat-history')?.textContent)
+        .not.toMatch(/only its first section/);
+    });
+
+    it('ignores an empty question', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      vi.clearAllMocks();
+
+      /** @type {HTMLTextAreaElement} */ (document.getElementById('chat-input')).value = '   ';
+      await popup.sendChatMessage();
+
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('shows the error in the thread when an answer fails', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      chrome.runtime.sendMessage.mockResolvedValue({ success: false, error: 'provider down' });
+
+      /** @type {HTMLTextAreaElement} */ (document.getElementById('chat-input')).value = 'Q?';
+      await popup.sendChatMessage();
+
+      expect(document.getElementById('chat-history')?.textContent).toContain('provider down');
+    });
+  });
+
+  describe('translation', () => {
+    it('sends the chosen source and target languages', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+
+      /** @type {HTMLSelectElement} */ (document.getElementById('source-language')).value = 'French';
+      /** @type {HTMLSelectElement} */ (document.getElementById('target-language')).value = 'de';
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: true,
+        data: { text: 'Übersetzung', provider: 'openai', model: 'gpt-4o-mini' }
+      });
+
+      await popup.translateContent();
+
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionType: 'TRANSLATE_CONTENT',
+          payload: expect.objectContaining({ sourceLanguage: 'French', targetLanguage: 'de' })
+        })
+      );
+      expect(document.getElementById('translation-content')?.innerHTML).toContain('Übersetzung');
+    });
+  });
+
+  describe('analysis', () => {
+    it('computes readability locally without an API call', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      vi.clearAllMocks();
+
+      await popup.runAnalysis('readability');
+
+      expect(chrome.runtime.sendMessage).not.toHaveBeenCalled();
+      expect(text('readability-result')).toMatch(/Flesch reading ease/);
+    });
+
+    it('renders parsed sentiment fields', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: true,
+        data: { sentiment: 'positive', reason: 'upbeat tone' }
+      });
+
+      await popup.runAnalysis('sentiment');
+
+      expect(text('sentiment-result')).toBe('positive — upbeat tone');
+    });
+
+    it('joins tags into a readable list', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      chrome.runtime.sendMessage.mockResolvedValue({
+        success: true,
+        data: { tags: ['ai', 'browsers'] }
+      });
+
+      await popup.runAnalysis('tags');
+
+      expect(text('tags-result')).toBe('ai, browsers');
+    });
+
+    it('shows the error in the card when analysis fails', async () => {
+      const popup = await createPopup({
+        tab: HTTP_TAB,
+        responses: { EXTRACT_PAGE_CONTENT: PAGE_CONTENT }
+      });
+      chrome.runtime.sendMessage.mockResolvedValue({ success: false, error: 'no key' });
+
+      await popup.runAnalysis('sentiment');
+
+      expect(text('sentiment-result')).toContain('no key');
+    });
+  });
+});

--- a/tests/utils/logger.test.js
+++ b/tests/utils/logger.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Logger } from '../../utils/logger.js';
+
+describe('Logger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('tags every line with its context so service worker logs are traceable', () => {
+    new Logger('BackgroundService').info('Service initialized');
+
+    expect(console.info).toHaveBeenCalledWith('[BackgroundService] Service initialized', '');
+  });
+
+  it('passes structured data through when given', () => {
+    new Logger('Test').warn('Retrying', { attempt: 2 });
+
+    expect(console.warn).toHaveBeenCalledWith('[Test] Retrying', { attempt: 2 });
+  });
+
+  it('suppresses levels below the configured one', () => {
+    // Default level is info, so debug should not reach the console.
+    new Logger('Test').debug('noisy detail');
+
+    expect(console.debug).not.toHaveBeenCalled();
+  });
+
+  it('emits every level at or above the configured one', () => {
+    const logger = new Logger('Test');
+
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(console.info).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('can be turned up to debug for troubleshooting', () => {
+    const logger = new Logger('Test');
+    logger.setLogLevel('debug');
+
+    logger.debug('now visible');
+
+    expect(console.debug).toHaveBeenCalledWith('[Test] now visible', '');
+  });
+
+  it('can be turned down to error only', () => {
+    const logger = new Logger('Test');
+    logger.setLogLevel('error');
+
+    logger.info('hidden');
+    logger.warn('also hidden');
+    logger.error('shown');
+
+    expect(console.info).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('does not throw on an unrecognised level', () => {
+    const logger = new Logger('Test');
+    logger.setLogLevel('nonsense');
+
+    expect(() => logger.info('still works')).not.toThrow();
+  });
+
+  it('defaults its context when none is given', () => {
+    new Logger().info('anonymous');
+
+    expect(console.info).toHaveBeenCalledWith('[GenAI] anonymous', '');
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -22,21 +22,40 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
-      exclude: [
-        'coverage/**',
-        'dist/**',
-        '**/node_modules/**',
-        '**/tests/**',
-        '**/*.config.*',
-        '**/*.d.ts'
+
+      // Report on every shipped source file, including ones no test imports.
+      // Without this, a file with no tests is simply absent from the table and
+      // reads as "fine" rather than "uncovered".
+      all: true,
+      include: [
+        'background.js',
+        'content.js',
+        'options.js',
+        'core/**/*.js',
+        'providers/**/*.js',
+        'scripts/**/*.js',
+        'services/**/*.js',
+        'src/**/*.js',
+        'utils/**/*.js'
       ],
+      exclude: ['coverage/**', 'dist/**', '**/node_modules/**', '**/*.config.*', '**/*.d.ts'],
+
+      // Vitest reads these keys flat. The previous config nested them under a
+      // `global` key — the Jest shape — which Vitest treats as a glob pattern
+      // matching no file, so the gate silently enforced nothing while the suite
+      // sat below the number it claimed to require.
+      //
+      // Set at the level the suite actually holds, so any regression fails the
+      // build. Raise as coverage improves; never lower them to go green.
+      //
+      // The remaining drag is storage-service.js (~50%) and
+      // validation-service.js (~67%) — pre-existing modules whose export,
+      // import, and cleanup paths have no tests yet.
       thresholds: {
-        global: {
-          branches: 70,
-          functions: 70,
-          lines: 70,
-          statements: 70
-        }
+        statements: 83,
+        branches: 83,
+        functions: 84,
+        lines: 83
       }
     },
     testTimeout: 10000,


### PR DESCRIPTION
> Stacked on #14 (which is stacked on #13). Review those first; GitHub retargets automatically as each merges.

## Description

I flagged that the coverage numbers were misleading. Investigating turned up something worse than misleading reporting: **the coverage gate was enforcing nothing at all.**

### The gate was inert

```js
thresholds: { global: { lines: 70, ... } }   // Jest shape
```

Vitest reads `thresholds` flat and treats `global` as a *glob pattern*, which matched no file. So `npm run test:coverage` exited `0` while reporting **63%** against a stated **70%** requirement. It had never failed a build.

Fixed to the flat shape, pinned to what the suite actually holds, and **verified it fails** by temporarily raising a threshold and confirming exit `1`.

Also set `all: true`: without it, a source file no test imports is absent from the table entirely, which reads as "fine" rather than "uncovered". That is precisely how `content.js` and `options.js` sat at zero without anyone noticing.

### The zeroes were half-true

`content.js` and `options.js` *were* exercised by the e2e suite, so the numbers were misleading — but they also hid genuine gaps. `popup-main.js` at 33% was not misleading at all: only its pure helpers were tested, leaving the part that decides whether a page is readable entirely uncovered.

| File | Before | After |
| --- | --- | --- |
| `content.js` | 0% | **96%** |
| `options.js` | 0% | **99%** |
| `scripts/popup-main.js` | 33% | **84%** |
| `utils/logger.js` | 84% (57% funcs) | **100%** |
| **Overall** | **63%** | **84%** |

Tests: **195** (was 128). E2E: 13 in real Chrome.

### The activeTab gap, partially closed

I'd said the `activeTab` path was unverifiable because Chrome grants it only on a real toolbar-icon click that Playwright cannot perform. That is true of the *grant*, but not of our half of the contract. The controller's behaviour when `tab.url` is withheld — exactly what the popup sees without the grant — now has coverage, alongside the granted-and-readable, `chrome://`, no-tab, and background-failure cases.

## A regression this PR caused and caught

Worth calling out, because it is the strongest argument for the e2e suite existing.

To unit-test `content.js` I added `export class`. **That broke the extension.** A declarative MV3 content script is loaded as a *classic* script, where ESM syntax is a parse error — Chrome offers no `"type": "module"` for `content_scripts`. The script silently never loaded and every extraction returned `Receiving end does not exist`.

**All 195 unit tests passed throughout.** Only the real-browser suite caught it, with 3 failures.

`content.js` now exposes its class on `globalThis` instead, and a unit test asserts the file stays ESM-free — so the next person to try this gets a millisecond failure instead of a browser launch. Documented in `docs/DEVELOPMENT.md`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test coverage improvement
- [x] Documentation update

## Testing

```
195 tests (was 128) · 13 e2e in real Chrome · 0 lint · 0 typecheck · 4 bundles
coverage gate: enforced, exits 1 on breach (verified)
```

Two incidental findings, both documented in the commits:

- `options.js` calls bare `confirm()`, which resolves on `globalThis`, while `tests/setup.js` builds its *own* JSDOM for `window`. Patching `window.confirm` silently targets a different object — a trap for anyone writing tests here next.
- Waiting on a rendered outcome beats counting microtask turns when a constructor kicks off async initialisation.

## Known Limitations

- Overall sits at 84%, dragged by `storage-service.js` (~50%) and `validation-service.js` (~67%) — pre-existing modules whose export/import/cleanup paths have no tests. Deliberately not addressed here to keep this PR about the reporting defect.
- Coverage reflects only the Vitest run; Playwright drives a separate process and contributes nothing to it. Now stated in the docs so the numbers are not over-read again.
